### PR TITLE
feat(mvp): open ChatGPT from context menu click

### DIFF
--- a/service_worker.test.mjs
+++ b/service_worker.test.mjs
@@ -1,0 +1,68 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import vm from 'node:vm';
+
+async function loadServiceWorker() {
+  const source = await readFile(new URL('./src/service_worker.js', import.meta.url), 'utf8');
+  const tabCreateCalls = [];
+
+  const context = {
+    chrome: {
+      contextMenus: {
+        create() {},
+        removeAll(callback) {
+          callback();
+        },
+        onClicked: {
+          addListener(listener) {
+            context.onContextMenuClicked = listener;
+          },
+        },
+      },
+      runtime: {
+        onInstalled: {
+          addListener(listener) {
+            context.onInstalled = listener;
+          },
+        },
+      },
+      tabs: {
+        create(details) {
+          tabCreateCalls.push(details);
+        },
+      },
+    },
+    console: {
+      log() {},
+    },
+    Date,
+  };
+
+  vm.createContext(context);
+  vm.runInContext(source, context);
+
+  return {
+    onContextMenuClicked: context.onContextMenuClicked,
+    tabCreateCalls,
+  };
+}
+
+test('opens ChatGPT in a new tab when the context menu item is clicked', async () => {
+  const { onContextMenuClicked, tabCreateCalls } = await loadServiceWorker();
+
+  onContextMenuClicked(
+    {
+      menuItemId: 'send-to-chatgpt',
+      selectionText: 'hello world',
+    },
+    {
+      id: 7,
+      title: 'Example',
+      url: 'https://example.com/article',
+    },
+  );
+
+  assert.equal(tabCreateCalls.length, 1);
+  assert.equal(tabCreateCalls[0].url, 'https://chatgpt.com/');
+});

--- a/src/service_worker.js
+++ b/src/service_worker.js
@@ -1,4 +1,5 @@
 const MENU_ID = 'send-to-chatgpt';
+const CHATGPT_URL = 'https://chatgpt.com/';
 
 function createContextMenu() {
   chrome.contextMenus.create({
@@ -25,6 +26,8 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
     tabId: tab?.id ?? null,
     timestamp: new Date().toISOString(),
   };
+
+  chrome.tabs.create({ url: CHATGPT_URL });
 
   console.log('[ChatGPT Web Injector] Context menu clicked:', payload);
 });


### PR DESCRIPTION
## Why
- make the current context-menu flow produce an immediate visible result for users
- keep the MVP behavior small and aligned with the existing service-worker architecture

## What Changed
- open a new `https://chatgpt.com/` tab when `Send to ChatGPT` is clicked
- keep the existing payload logging in the background worker
- add a lightweight Node regression test for the click handler using a fake Chrome API

## Related Issues
- Related to #1

## Files
- `src/service_worker.js`
- `service_worker.test.mjs`

## Verification
- `node --test service_worker.test.mjs`
- `node --check src/service_worker.js`

## Follow-up
- prompt composition, content injection, auto-send, and fallback UI remain follow-up work under the broader send-flow issue