### PR TITLE
feat: browser action popup for quick template switching

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -32,6 +32,7 @@
   },
   "action": {
     "default_title": "ChatGPT Web Injector",
+    "default_popup": "popup/popup.html",
     "default_icon": {
       "16": "icons/icon16.png",
       "32": "icons/icon32.png",

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -1,0 +1,100 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-size: 14px;
+  color: #1a1a1a;
+  background: #fff;
+  min-width: 220px;
+  max-width: 300px;
+}
+
+.container {
+  padding: 12px 0 0;
+}
+
+h1 {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #888;
+  padding: 0 14px 8px;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.template-list {
+  list-style: none;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.template-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 14px;
+  cursor: pointer;
+  border-radius: 0;
+  transition: background 0.1s;
+  user-select: none;
+}
+
+.template-item:hover {
+  background: #f5f5f5;
+}
+
+.template-item.is-active {
+  background: #f0f7ff;
+}
+
+.template-item.is-active:hover {
+  background: #e5f0ff;
+}
+
+.template-item__check {
+  width: 16px;
+  font-size: 13px;
+  color: #0070f3;
+  flex-shrink: 0;
+  text-align: center;
+}
+
+.template-item__name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.template-item.is-active .template-item__name {
+  font-weight: 600;
+  color: #0070f3;
+}
+
+.footer {
+  border-top: 1px solid #f0f0f0;
+  padding: 8px 14px;
+}
+
+.manage-link {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 12px;
+  color: #888;
+  padding: 0;
+  text-decoration: none;
+  transition: color 0.1s;
+}
+
+.manage-link:hover {
+  color: #1a1a1a;
+  text-decoration: underline;
+}

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -9,7 +9,7 @@
   <body>
     <div class="container">
       <h1>Templates</h1>
-      <ul id="template-list" class="template-list"></ul>
+      <ul id="template-list" class="template-list" role="listbox" aria-label="Templates"></ul>
       <div class="footer">
         <button id="manage-btn" type="button" class="manage-link">Manage templates</button>
       </div>

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ChatGPT Web Injector</title>
+    <link rel="stylesheet" href="./popup.css" />
+  </head>
+  <body>
+    <div class="container">
+      <h1>Templates</h1>
+      <ul id="template-list" class="template-list"></ul>
+      <div class="footer">
+        <button id="manage-btn" type="button" class="manage-link">Manage templates</button>
+      </div>
+    </div>
+    <script type="module" src="./popup.js"></script>
+  </body>
+</html>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -14,6 +14,9 @@ function render() {
     const li = document.createElement('li');
     li.className = `template-item${isActive ? ' is-active' : ''}`;
     li.dataset.id = tpl.id;
+    li.setAttribute('role', 'option');
+    li.setAttribute('aria-selected', String(isActive));
+    li.setAttribute('tabindex', '0');
 
     const check = document.createElement('span');
     check.className = 'template-item__check';
@@ -29,20 +32,49 @@ function render() {
   }
 }
 
-listEl.addEventListener('click', async (e) => {
+async function selectTemplate(id) {
+  if (!id || id === state.activeTemplateId) {
+    return;
+  }
+
+  const prevId = state.activeTemplateId;
+  state.activeTemplateId = id;
+  render();
+
+  try {
+    await saveTemplates(state.templates, state.activeTemplateId);
+  } catch (err) {
+    console.error('[ChatGPT Web Injector] Failed to save active template:', err);
+    state.activeTemplateId = prevId;
+    render();
+  }
+}
+
+listEl.addEventListener('click', (e) => {
   const item = e.target.closest('.template-item');
   if (!item) {
     return;
   }
 
-  const { id } = item.dataset;
-  if (!id || id === state.activeTemplateId) {
+  selectTemplate(item.dataset.id).catch((err) => {
+    console.error('[ChatGPT Web Injector] Select template failed:', err);
+  });
+});
+
+listEl.addEventListener('keydown', (e) => {
+  if (e.key !== 'Enter' && e.key !== ' ') {
     return;
   }
 
-  state.activeTemplateId = id;
-  await saveTemplates(state.templates, state.activeTemplateId);
-  render();
+  const item = e.target.closest('.template-item');
+  if (!item) {
+    return;
+  }
+
+  e.preventDefault();
+  selectTemplate(item.dataset.id).catch((err) => {
+    console.error('[ChatGPT Web Injector] Select template failed:', err);
+  });
 });
 
 manageBtn.addEventListener('click', () => {

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -1,0 +1,60 @@
+import { loadTemplates, saveTemplates } from '../src/storage.js';
+
+const listEl = document.getElementById('template-list');
+const manageBtn = document.getElementById('manage-btn');
+
+let state = { templates: [], activeTemplateId: '' };
+
+function render() {
+  listEl.innerHTML = '';
+
+  for (const tpl of state.templates) {
+    const isActive = tpl.id === state.activeTemplateId;
+
+    const li = document.createElement('li');
+    li.className = `template-item${isActive ? ' is-active' : ''}`;
+    li.dataset.id = tpl.id;
+
+    const check = document.createElement('span');
+    check.className = 'template-item__check';
+    check.textContent = isActive ? '✓' : '';
+    check.setAttribute('aria-hidden', 'true');
+
+    const name = document.createElement('span');
+    name.className = 'template-item__name';
+    name.textContent = tpl.name;
+
+    li.append(check, name);
+    listEl.appendChild(li);
+  }
+}
+
+listEl.addEventListener('click', async (e) => {
+  const item = e.target.closest('.template-item');
+  if (!item) {
+    return;
+  }
+
+  const { id } = item.dataset;
+  if (!id || id === state.activeTemplateId) {
+    return;
+  }
+
+  state.activeTemplateId = id;
+  await saveTemplates(state.templates, state.activeTemplateId);
+  render();
+});
+
+manageBtn.addEventListener('click', () => {
+  chrome.tabs.create({ url: chrome.runtime.getURL('options/options.html') });
+  window.close();
+});
+
+async function init() {
+  state = await loadTemplates();
+  render();
+}
+
+init().catch((err) => {
+  console.error('[ChatGPT Web Injector] Popup load failed:', err);
+});


### PR DESCRIPTION
## Summary
- Adds `popup/popup.html`, `popup/popup.js`, `popup/popup.css` — a lightweight browser action popup
- Wires `action.default_popup` in `manifest.json`
- Clicking the extension icon lists all saved templates; active template is highlighted with a ✓ and blue text
- Clicking any other template sets it as the new active default (writes to `chrome.storage.sync`); the existing `storage.onChanged` listener in `service_worker.js` rebuilds the context menu automatically
- "Manage templates" button opens the Options page in a new tab

## Acceptance Criteria
- [x] Clicking extension icon opens popup listing all template names
- [x] Active template visually distinguished (✓ + blue colour)
- [x] Clicking inactive template → sets as active, popup updates immediately
- [x] Context menu submenu rebuilds automatically (via existing `storage.onChanged`)
- [x] "Manage templates" opens `options/options.html` in a new tab
- [x] Works with 1, 3, 10 templates (no hard-coded limits; list scrollable past 320px)
- [x] `npm test` → 6/6 pass
- [x] `node --check` clean on all JS files
- [x] All `manifest.json` paths resolve to existing files

## Files changed
| File | Change |
|------|--------|
| `popup/popup.html` | new |
| `popup/popup.js` | new |
| `popup/popup.css` | new |
| `manifest.json` | add `action.default_popup` |

closes #22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a popup interface accessible from the extension icon.
  * View and select active templates directly from the popup.
  * "Manage templates" button opens full configuration.
  * Keyboard activation (Enter/Space) and visual active-state highlighting for better accessibility.
  * Improved popup layout and styling for consistent, responsive appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->