### PR TITLE
feat: add YouTube caption summary flow

### DIFF
--- a/docs/plans/2026-05-06-youtube-caption-summary.md
+++ b/docs/plans/2026-05-06-youtube-caption-summary.md
@@ -1,0 +1,91 @@
+# YouTube Caption Summary Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a YouTube-only caption summary button that uses a dedicated editable prompt template and sends the rendered prompt to ChatGPT automatically.
+
+**Architecture:** Add a small YouTube content script for button placement and caption extraction, then reuse the existing service worker ChatGPT send flow. Keep the YouTube Summary template separate from the existing selection templates so normal selection behavior is unchanged.
+
+**Tech Stack:** Chrome Extension Manifest V3, plain JavaScript ESM where supported, DOM APIs, `chrome.storage.sync`, `chrome.scripting.executeScript`, Node built-in test runner, jsdom.
+
+### Task 1: Template Rendering
+
+**Files:**
+- Modify: `src/template.js`
+- Test: `tests/template.test.js`
+
+**Steps:**
+1. Write failing tests for rendering `{{transcript}}` while preserving existing `{{selection}}`, `{{title}}`, and `{{url}}`.
+2. Run `node --test tests/template.test.js` and confirm the new test fails because `{{transcript}}` is not replaced.
+3. Add minimal transcript variable replacement to `renderTemplate`.
+4. Run `node --test tests/template.test.js` and confirm it passes.
+
+### Task 2: YouTube Summary Template Storage
+
+**Files:**
+- Modify: `src/storage.js`
+- Test: `tests/storage.test.js`
+
+**Steps:**
+1. Write failing tests for loading, saving, and resetting a dedicated YouTube Summary template.
+2. Run `node --test tests/storage.test.js` and confirm exports are missing.
+3. Implement `DEFAULT_YOUTUBE_SUMMARY_TEMPLATE`, `loadYoutubeSummaryTemplate`, `saveYoutubeSummaryTemplate`, and `resetYoutubeSummaryTemplate`.
+4. Run `node --test tests/storage.test.js` and confirm it passes.
+
+### Task 3: YouTube Transcript Helpers
+
+**Files:**
+- Create: `src/youtube_transcript.js`
+- Test: `tests/youtube_transcript.test.js`
+
+**Steps:**
+1. Write failing tests for caption track selection and XML transcript cleanup.
+2. Run `node --test tests/youtube_transcript.test.js` and confirm module/export failure.
+3. Implement defensive helpers for choosing the active/default caption track and parsing transcript XML.
+4. Run `node --test tests/youtube_transcript.test.js` and confirm it passes.
+
+### Task 4: Service Worker Message Flow
+
+**Files:**
+- Modify: `src/service_worker.js`
+- Test: syntax check only unless message flow is refactored into testable pure functions.
+
+**Steps:**
+1. Add `YOUTUBE_SUMMARY_SEND` handling that renders the dedicated YouTube Summary template.
+2. Reuse the existing ChatGPT open-tab and injection flow.
+3. Run `node --check src/service_worker.js`.
+
+### Task 5: YouTube Content Script UI
+
+**Files:**
+- Create: `src/youtube_summary.js`
+- Create: `src/youtube_summary.css`
+- Modify: `manifest.json`
+
+**Steps:**
+1. Add a YouTube-specific content script matched to `https://www.youtube.com/*`.
+2. Insert a compact summary button near player controls on watch pages.
+3. On click, extract title, URL, and transcript, then send `YOUTUBE_SUMMARY_SEND`.
+4. Show a short failure message when captions are unavailable.
+5. Run `node --check src/youtube_summary.js` and verify manifest paths exist.
+
+### Task 6: Options UI
+
+**Files:**
+- Modify: `options/options.html`
+- Modify: `options/options.js`
+- Modify: `options/options.css`
+
+**Steps:**
+1. Add a separate YouTube Summary Template editor.
+2. Wire save and reset to dedicated storage helpers.
+3. Run `node --check options/options.js`.
+
+### Task 7: Verification and PR
+
+**Steps:**
+1. Run `npm test`.
+2. Run `node --check` for every changed JavaScript file.
+3. Commit with a Conventional Commit message.
+4. Push the branch.
+5. Open a PR with `closes #26`.

--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,7 @@
   "content_scripts": [
     {
       "matches": ["https://www.youtube.com/*"],
-      "js": ["src/youtube_summary.js"],
+      "js": ["src/youtube_transcript.js", "src/youtube_summary.js"],
       "css": ["src/youtube_summary.css"],
       "run_at": "document_idle"
     },

--- a/manifest.json
+++ b/manifest.json
@@ -11,6 +11,12 @@
   },
   "content_scripts": [
     {
+      "matches": ["https://www.youtube.com/*"],
+      "js": ["src/youtube_summary.js"],
+      "css": ["src/youtube_summary.css"],
+      "run_at": "document_idle"
+    },
+    {
       "matches": ["<all_urls>"],
       "js": ["src/selection_tooltip.js"],
       "css": ["src/selection_tooltip.css"],

--- a/options/options.css
+++ b/options/options.css
@@ -30,6 +30,10 @@ h2 {
   color: #4b5563;
 }
 
+.settings-section {
+  margin-bottom: 28px;
+}
+
 /* ---- Template list ---- */
 
 .templates-header {

--- a/options/options.html
+++ b/options/options.html
@@ -11,29 +11,49 @@
       <h1>ChatGPT Web Injector</h1>
       <p class="subtitle">Manage your prompt templates. The active template is used by the floating button and as the default send action.</p>
 
-      <div class="templates-header">
-        <h2>Templates</h2>
-        <button id="add-template" type="button" class="btn-secondary">+ New template</button>
-      </div>
+      <section class="settings-section">
+        <div class="templates-header">
+          <h2>Templates</h2>
+          <button id="add-template" type="button" class="btn-secondary">+ New template</button>
+        </div>
 
-      <ul id="template-list" class="template-list"></ul>
+        <ul id="template-list" class="template-list"></ul>
 
-      <div id="editor" class="editor hidden">
-        <label for="tpl-name">Name</label>
-        <input id="tpl-name" type="text" placeholder="e.g. Summarize" maxlength="40" />
+        <div id="editor" class="editor hidden">
+          <label for="tpl-name">Name</label>
+          <input id="tpl-name" type="text" placeholder="e.g. Summarize" maxlength="40" />
 
-        <label for="tpl-body">Prompt template</label>
-        <textarea id="tpl-body" rows="12" spellcheck="false"></textarea>
+          <label for="tpl-body">Prompt template</label>
+          <textarea id="tpl-body" rows="12" spellcheck="false"></textarea>
+
+          <p class="variables">
+            Available variables: <code>{{selection}}</code>, <code>{{title}}</code>, <code>{{url}}</code>
+          </p>
+
+          <div class="actions">
+            <button id="save-tpl" type="button">Save</button>
+            <button id="cancel-tpl" type="button" class="btn-secondary">Cancel</button>
+          </div>
+        </div>
+      </section>
+
+      <section class="settings-section">
+        <div class="templates-header">
+          <h2>YouTube Summary Template</h2>
+          <button id="reset-youtube-tpl" type="button" class="btn-secondary">Reset</button>
+        </div>
+
+        <label for="youtube-tpl-body">Prompt template</label>
+        <textarea id="youtube-tpl-body" rows="12" spellcheck="false"></textarea>
 
         <p class="variables">
-          Available variables: <code>{{selection}}</code>, <code>{{title}}</code>, <code>{{url}}</code>
+          Available variables: <code>{{title}}</code>, <code>{{url}}</code>, <code>{{transcript}}</code>
         </p>
 
         <div class="actions">
-          <button id="save-tpl" type="button">Save</button>
-          <button id="cancel-tpl" type="button" class="btn-secondary">Cancel</button>
+          <button id="save-youtube-tpl" type="button">Save YouTube template</button>
         </div>
-      </div>
+      </section>
 
       <p id="status" role="status" aria-live="polite"></p>
     </main>

--- a/options/options.js
+++ b/options/options.js
@@ -1,5 +1,12 @@
 import { DEFAULT_TEMPLATE } from '../src/template.js';
-import { loadTemplates, saveTemplates, makeId } from '../src/storage.js';
+import {
+  loadTemplates,
+  loadYoutubeSummaryTemplate,
+  makeId,
+  resetYoutubeSummaryTemplate,
+  saveTemplates,
+  saveYoutubeSummaryTemplate,
+} from '../src/storage.js';
 
 const listEl = document.getElementById('template-list');
 const editorEl = document.getElementById('editor');
@@ -8,6 +15,9 @@ const bodyInput = document.getElementById('tpl-body');
 const saveTplBtn = document.getElementById('save-tpl');
 const cancelTplBtn = document.getElementById('cancel-tpl');
 const addTplBtn = document.getElementById('add-template');
+const youtubeBodyInput = document.getElementById('youtube-tpl-body');
+const saveYoutubeTplBtn = document.getElementById('save-youtube-tpl');
+const resetYoutubeTplBtn = document.getElementById('reset-youtube-tpl');
 const statusEl = document.getElementById('status');
 
 let state = { templates: [], activeTemplateId: '' };
@@ -169,8 +179,28 @@ saveTplBtn.addEventListener('click', () => {
 
 cancelTplBtn.addEventListener('click', closeEditor);
 
+saveYoutubeTplBtn.addEventListener('click', () => {
+  saveYoutubeSummaryTemplate(youtubeBodyInput.value).then(() => {
+    setStatus('YouTube Summary template saved.');
+  }).catch((err) => {
+    console.error('[ChatGPT Web Injector] YouTube template save failed:', err);
+    setStatus('Save failed. Please try again.');
+  });
+});
+
+resetYoutubeTplBtn.addEventListener('click', () => {
+  resetYoutubeSummaryTemplate().then((template) => {
+    youtubeBodyInput.value = template;
+    setStatus('YouTube Summary template reset.');
+  }).catch((err) => {
+    console.error('[ChatGPT Web Injector] YouTube template reset failed:', err);
+    setStatus('Reset failed. Please try again.');
+  });
+});
+
 async function init() {
   state = await loadTemplates();
+  youtubeBodyInput.value = await loadYoutubeSummaryTemplate();
   renderList();
 }
 

--- a/src/selection_tooltip.js
+++ b/src/selection_tooltip.js
@@ -1,3 +1,4 @@
+(function initSelectionTooltipContentScript() {
 const TOOLTIP_ID = 'chatgpt-web-injector-tooltip';
 const SHOW_DELAY_MS = 100;
 const TOOLTIP_MOUSE_OFFSET = 12;
@@ -177,3 +178,4 @@ document.addEventListener('keyup', () => {
   processSelection();
 }, true);
 log('Event listeners registered (with capture phase)');
+}());

--- a/src/service_worker.js
+++ b/src/service_worker.js
@@ -1,5 +1,5 @@
 import { runChatgptSendFlow } from './chatgpt_content.js';
-import { loadTemplates, loadTemplateById } from './storage.js';
+import { loadTemplates, loadTemplateById, loadYoutubeSummaryTemplate } from './storage.js';
 import { renderTemplate } from './template.js';
 
 const MENU_ID = 'send-to-chatgpt';
@@ -42,7 +42,10 @@ async function sendWithTemplate(templateId, selectionText, tab) {
 
   const template = await loadTemplateById(templateId);
   const prompt = renderTemplate(template, payload);
+  await sendPromptToChatgpt(prompt);
+}
 
+async function sendPromptToChatgpt(prompt) {
   const targetTab = await chrome.tabs.create({ url: CHATGPT_URL, active: true });
   await waitForTabComplete(targetTab.id, TAB_WAIT_TIMEOUT_MS);
 
@@ -53,6 +56,17 @@ async function sendWithTemplate(templateId, selectionText, tab) {
   });
 
   console.log('[ChatGPT Web Injector] Runtime send result:', result?.result || result);
+}
+
+async function sendYoutubeSummary(payload) {
+  const template = await loadYoutubeSummaryTemplate();
+  const prompt = renderTemplate(template, {
+    title: payload?.title || '',
+    url: payload?.url || '',
+    transcript: payload?.transcript || '',
+  });
+
+  await sendPromptToChatgpt(prompt);
 }
 
 async function rebuildContextMenuOnce() {
@@ -139,6 +153,13 @@ chrome.contextMenus.onClicked.addListener(async (info, tab) => {
 });
 
 chrome.runtime.onMessage.addListener((message, sender) => {
+  if (message?.type === 'YOUTUBE_SUMMARY_SEND') {
+    sendYoutubeSummary(message.payload).catch((error) => {
+      console.error('[ChatGPT Web Injector] YouTube summary send flow failed:', error);
+    });
+    return;
+  }
+
   if (message?.type !== 'SELECTION_SEND') {
     return;
   }

--- a/src/storage.js
+++ b/src/storage.js
@@ -3,6 +3,30 @@ import { DEFAULT_TEMPLATE, getEffectiveTemplate } from './template.js';
 const LEGACY_KEY = 'defaultTemplate';
 const TEMPLATES_KEY = 'templates';
 const ACTIVE_ID_KEY = 'activeTemplateId';
+const YOUTUBE_SUMMARY_TEMPLATE_KEY = 'youtubeSummaryTemplate';
+
+export const DEFAULT_YOUTUBE_SUMMARY_TEMPLATE = `You are a precise video summary assistant.
+
+Video title: {{title}}
+Video URL: {{url}}
+
+Transcript:
+{{transcript}}
+
+Please provide:
+1) Concise overall summary
+2) Key points
+3) Important arguments or claims
+4) Actionable takeaways
+5) Notable timestamps if useful`;
+
+function getEffectiveYoutubeSummaryTemplate(template) {
+  if (typeof template !== 'string') {
+    return DEFAULT_YOUTUBE_SUMMARY_TEMPLATE;
+  }
+
+  return template.trim() ? template : DEFAULT_YOUTUBE_SUMMARY_TEMPLATE;
+}
 
 export function makeId() {
   return `tpl_${crypto.randomUUID()}`;
@@ -79,4 +103,19 @@ export async function saveTemplate(body) {
 export async function resetTemplate() {
   await saveTemplate(DEFAULT_TEMPLATE);
   return DEFAULT_TEMPLATE;
+}
+
+export async function loadYoutubeSummaryTemplate() {
+  const data = await chrome.storage.sync.get([YOUTUBE_SUMMARY_TEMPLATE_KEY]);
+  return getEffectiveYoutubeSummaryTemplate(data[YOUTUBE_SUMMARY_TEMPLATE_KEY]);
+}
+
+export async function saveYoutubeSummaryTemplate(body) {
+  const template = getEffectiveYoutubeSummaryTemplate(body);
+  await chrome.storage.sync.set({ [YOUTUBE_SUMMARY_TEMPLATE_KEY]: template });
+}
+
+export async function resetYoutubeSummaryTemplate() {
+  await saveYoutubeSummaryTemplate(DEFAULT_YOUTUBE_SUMMARY_TEMPLATE);
+  return DEFAULT_YOUTUBE_SUMMARY_TEMPLATE;
 }

--- a/src/template.js
+++ b/src/template.js
@@ -24,9 +24,11 @@ export function renderTemplate(template, variables) {
   const selection = variables?.selection ?? '';
   const title = variables?.title ?? '';
   const url = variables?.url ?? '';
+  const transcript = variables?.transcript ?? '';
 
   return effectiveTemplate
     .replaceAll('{{selection}}', selection)
     .replaceAll('{{title}}', title)
-    .replaceAll('{{url}}', url);
+    .replaceAll('{{url}}', url)
+    .replaceAll('{{transcript}}', transcript);
 }

--- a/src/youtube_summary.css
+++ b/src/youtube_summary.css
@@ -1,0 +1,60 @@
+#chatgpt-web-injector-youtube-summary {
+  min-width: 36px;
+  height: 36px;
+  margin: 0 2px;
+  border: none;
+  border-radius: 18px;
+  background: rgba(16, 163, 127, 0.92);
+  color: #fff;
+  cursor: pointer;
+  font-family: Roboto, Arial, sans-serif;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 36px;
+  padding: 0 10px;
+  text-align: center;
+  vertical-align: top;
+}
+
+#chatgpt-web-injector-youtube-summary:hover {
+  background: #10a37f;
+}
+
+#chatgpt-web-injector-youtube-summary:disabled {
+  cursor: wait;
+  opacity: 0.75;
+}
+
+#chatgpt-web-injector-youtube-summary.is-loading {
+  color: transparent;
+  position: relative;
+}
+
+#chatgpt-web-injector-youtube-summary.is-loading::after {
+  content: '';
+  position: absolute;
+  inset: 10px;
+  border: 2px solid rgba(255, 255, 255, 0.45);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: chatgpt-web-injector-spin 0.75s linear infinite;
+}
+
+#chatgpt-web-injector-youtube-status {
+  display: inline-flex;
+  align-items: center;
+  height: 36px;
+  margin-left: 6px;
+  color: #fff;
+  font-family: Roboto, Arial, sans-serif;
+  font-size: 12px;
+  font-weight: 500;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.7);
+  vertical-align: top;
+}
+
+@keyframes chatgpt-web-injector-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/youtube_summary.js
+++ b/src/youtube_summary.js
@@ -3,11 +3,15 @@ const YOUTUBE_SUMMARY_STATUS_ID = 'chatgpt-web-injector-youtube-status';
 const YOUTUBE_WATCH_PATH = '/watch';
 const BUTTON_RETRY_MS = 750;
 const STATUS_TIMEOUT_MS = 2500;
+const MOUNT_DEBOUNCE_MS = 150;
+const OBSERVER_RETRY_MS = 500;
 const DEBUG = false;
 
 let lastUrl = '';
 let mountTimer = null;
 let statusTimer = null;
+let observerTimer = null;
+let observerRetryTimer = null;
 
 function log(...args) {
   if (DEBUG) {
@@ -53,43 +57,6 @@ function setButtonLoading(isLoading) {
   button.disabled = isLoading;
   button.classList.toggle('is-loading', isLoading);
   button.setAttribute('aria-busy', String(isLoading));
-}
-
-function decodeHtmlEntities(text) {
-  if (!text) {
-    return '';
-  }
-
-  const doc = new DOMParser().parseFromString(`<!doctype html><body>${text}`, 'text/html');
-  return doc.body.textContent ?? '';
-}
-
-function formatTimestamp(seconds) {
-  const totalSeconds = Math.max(0, Math.floor(Number(seconds) || 0));
-  const minutes = Math.floor(totalSeconds / 60);
-  const remainingSeconds = totalSeconds % 60;
-
-  return `${String(minutes).padStart(2, '0')}:${String(remainingSeconds).padStart(2, '0')}`;
-}
-
-function parseTranscriptXml(xml) {
-  const captions = [];
-  const textNodePattern = /<text\b([^>]*)>([\s\S]*?)<\/text>/g;
-  let match = textNodePattern.exec(xml);
-
-  while (match) {
-    const [, attrs, rawText] = match;
-    const start = attrs.match(/\bstart="([^"]+)"/)?.[1] ?? '0';
-    const text = decodeHtmlEntities(rawText.replaceAll('\n', ' ')).trim();
-
-    if (text) {
-      captions.push(`[${formatTimestamp(start)}] ${text}`);
-    }
-
-    match = textNodePattern.exec(xml);
-  }
-
-  return captions.join('\n');
 }
 
 function extractBalancedJson(text, marker) {
@@ -180,10 +147,28 @@ function getActiveCaptionLanguageCode() {
     return '';
   }
 
+  const captionStorageKeys = [
+    'yt-player-caption-display-settings',
+    'yt-player-caption-sticky-language',
+    'yt-player-caption-language-preferences',
+  ];
+
+  for (const key of captionStorageKeys) {
+    const value = window.localStorage.getItem(key) || '';
+    const languageCode = value?.match(/"languageCode"\s*:\s*"([^"]+)"/)?.[1];
+    if (languageCode) {
+      return languageCode;
+    }
+  }
+
   for (let i = 0; i < window.localStorage.length; i += 1) {
     const key = window.localStorage.key(i);
-    const value = key ? window.localStorage.getItem(key) : '';
-    const languageCode = value?.match(/"languageCode"\s*:\s*"([^"]+)"/)?.[1];
+    if (!key?.startsWith('yt-player-caption')) {
+      continue;
+    }
+
+    const value = window.localStorage.getItem(key) || '';
+    const languageCode = value.match(/"languageCode"\s*:\s*"([^"]+)"/)?.[1];
     if (languageCode) {
       return languageCode;
     }
@@ -192,29 +177,18 @@ function getActiveCaptionLanguageCode() {
   return '';
 }
 
-function chooseCaptionTrack(tracks, activeLanguageCode) {
-  const readableTracks = tracks.filter((track) => track?.baseUrl);
-  if (readableTracks.length === 0) {
-    return null;
-  }
-
-  if (activeLanguageCode) {
-    const activeTrack = readableTracks.find((track) => track.languageCode === activeLanguageCode);
-    if (activeTrack) {
-      return activeTrack;
-    }
-  }
-
-  const browserLanguage = navigator.language?.split('-')[0];
-  return readableTracks.find((track) => track.isDefault) ??
-    readableTracks.find((track) => track.languageCode === browserLanguage) ??
-    readableTracks[0];
-}
-
 async function getTranscript() {
-  const playerResponse = await fetchCurrentPlayerResponse().catch(() => getPlayerResponseFromPageScripts());
+  const transcriptHelpers = window.ChatgptWebInjectorYoutubeTranscript;
+  if (!transcriptHelpers) {
+    throw new Error('transcript_helpers_unavailable');
+  }
+
+  const playerResponse = getPlayerResponseFromPageScripts() ||
+    await fetchCurrentPlayerResponse().catch(() => null);
   const tracks = getCaptionTracks(playerResponse);
-  const track = chooseCaptionTrack(tracks, getActiveCaptionLanguageCode());
+  const track = transcriptHelpers.chooseCaptionTrack(tracks, {
+    activeLanguageCode: getActiveCaptionLanguageCode(),
+  });
 
   if (!track) {
     throw new Error('no_caption_track');
@@ -225,7 +199,7 @@ async function getTranscript() {
     throw new Error('caption_fetch_failed');
   }
 
-  const transcript = parseTranscriptXml(await response.text());
+  const transcript = transcriptHelpers.parseTranscriptXml(await response.text());
   if (!transcript) {
     throw new Error('empty_transcript');
   }
@@ -311,14 +285,31 @@ function handleNavigation() {
   lastUrl = window.location.href;
   removeButton();
   mountButton();
+  observePlayerControls();
 }
 
 document.addEventListener('yt-navigate-finish', handleNavigation, true);
 document.addEventListener('yt-page-data-updated', handleNavigation, true);
 
 const observer = new MutationObserver(() => {
-  mountButton();
+  clearTimeout(observerTimer);
+  observerTimer = setTimeout(() => {
+    mountButton();
+  }, MOUNT_DEBOUNCE_MS);
 });
 
-observer.observe(document.documentElement, { childList: true, subtree: true });
+function observePlayerControls() {
+  clearTimeout(observerRetryTimer);
+  observer.disconnect();
+
+  const controls = document.querySelector('.ytp-chrome-controls');
+  if (!controls) {
+    observerRetryTimer = setTimeout(observePlayerControls, OBSERVER_RETRY_MS);
+    return;
+  }
+
+  observer.observe(controls, { childList: true, subtree: true });
+}
+
+observePlayerControls();
 handleNavigation();

--- a/src/youtube_summary.js
+++ b/src/youtube_summary.js
@@ -128,6 +128,27 @@ function getPlayerResponseFromPageScripts() {
   return null;
 }
 
+function getInnertubeValue(name) {
+  const pattern = new RegExp(`"${name}"\\s*:\\s*"([^"]+)"`);
+  for (const script of document.scripts) {
+    const match = (script.textContent || '').match(pattern);
+    if (match) {
+      return match[1];
+    }
+  }
+  return '';
+}
+
+function getTranscriptParamsFromPageScripts() {
+  for (const script of document.scripts) {
+    const match = (script.textContent || '').match(/"getTranscriptEndpoint"\s*:\s*\{"params"\s*:\s*"([^"]+)"/);
+    if (match) {
+      return match[1];
+    }
+  }
+  return '';
+}
+
 async function fetchCurrentPlayerResponse() {
   const response = await fetch(window.location.href, { credentials: 'include' });
   if (!response.ok) {
@@ -135,6 +156,46 @@ async function fetchCurrentPlayerResponse() {
   }
 
   return getPlayerResponseFromHtml(await response.text());
+}
+
+async function fetchInnertubeTranscript() {
+  const key = getInnertubeValue('INNERTUBE_API_KEY');
+  const clientVersion = getInnertubeValue('INNERTUBE_CLIENT_VERSION');
+  const visitorData = getInnertubeValue('VISITOR_DATA');
+  const hl = getInnertubeValue('HL') || document.documentElement.lang || 'en';
+  const gl = getInnertubeValue('GL') || 'US';
+  const params = getTranscriptParamsFromPageScripts();
+
+  if (!key || !clientVersion || !params) {
+    return '';
+  }
+
+  const response = await fetch(`https://www.youtube.com/youtubei/v1/get_transcript?key=${key}`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: {
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      context: {
+        client: {
+          clientName: 'WEB',
+          clientVersion,
+          gl,
+          hl,
+          visitorData,
+        },
+      },
+      params,
+    }),
+  });
+
+  if (!response.ok) {
+    return '';
+  }
+
+  return window.ChatgptWebInjectorYoutubeTranscript
+    .parseInnertubeTranscriptResponse(await response.json());
 }
 
 function getCaptionTracks(playerResponse) {
@@ -201,11 +262,12 @@ async function getTranscript() {
   }
 
   const transcript = transcriptHelpers.parseTranscript(await response.text());
-  if (!transcript) {
+  const fallbackTranscript = transcript || await fetchInnertubeTranscript();
+  if (!fallbackTranscript) {
     throw new Error('empty_transcript');
   }
 
-  return transcript;
+  return fallbackTranscript;
 }
 
 async function sendYoutubeSummary() {

--- a/src/youtube_summary.js
+++ b/src/youtube_summary.js
@@ -195,7 +195,7 @@ async function getTranscript() {
     throw new Error('no_caption_track');
   }
 
-  const response = await fetch(track.baseUrl, { credentials: 'include' });
+  const response = await fetch(transcriptHelpers.buildCaptionUrl(track.baseUrl), { credentials: 'include' });
   if (!response.ok) {
     throw new Error('caption_fetch_failed');
   }

--- a/src/youtube_summary.js
+++ b/src/youtube_summary.js
@@ -6,6 +6,8 @@ const BUTTON_RETRY_MS = 750;
 const STATUS_TIMEOUT_MS = 2500;
 const MOUNT_DEBOUNCE_MS = 150;
 const OBSERVER_RETRY_MS = 500;
+const TRANSCRIPT_DOM_WAIT_MS = 3000;
+const TRANSCRIPT_DOM_POLL_MS = 200;
 const DEBUG = false;
 
 let lastUrl = '';
@@ -149,6 +151,75 @@ function getTranscriptParamsFromPageScripts() {
   return '';
 }
 
+function normalizeTimestamp(timestamp) {
+  const parts = timestamp.trim().split(':');
+  if (parts.length >= 2) {
+    return parts.slice(-2).map((part) => part.padStart(2, '0')).join(':');
+  }
+  return '00:00';
+}
+
+function readTranscriptFromDom() {
+  const segmentNodes = Array.from(document.querySelectorAll('ytd-transcript-segment-renderer'));
+  const lines = [];
+
+  for (const segment of segmentNodes) {
+    const timestamp = segment.querySelector('.segment-timestamp')?.textContent?.trim() || '';
+    const text = segment.querySelector('.segment-text')?.textContent?.trim() || '';
+
+    if (text) {
+      lines.push(`[${normalizeTimestamp(timestamp)}] ${text}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function findTranscriptButton() {
+  const labelPattern = /show transcript|transcript|文字稿|转录|轉錄|逐字稿/i;
+  const buttons = Array.from(document.querySelectorAll('button'));
+
+  return buttons.find((button) => {
+    const label = [
+      button.getAttribute('aria-label') || '',
+      button.textContent || '',
+    ].join(' ');
+    return labelPattern.test(label);
+  }) || null;
+}
+
+async function waitForTranscriptDom() {
+  const startedAt = Date.now();
+  let transcript = readTranscriptFromDom();
+
+  while (!transcript && Date.now() - startedAt < TRANSCRIPT_DOM_WAIT_MS) {
+    await new Promise((resolve) => { setTimeout(resolve, TRANSCRIPT_DOM_POLL_MS); });
+    transcript = readTranscriptFromDom();
+  }
+
+  return transcript;
+}
+
+async function fetchTranscriptFromDom() {
+  const visibleTranscript = readTranscriptFromDom();
+  if (visibleTranscript) {
+    return visibleTranscript;
+  }
+
+  const transcriptButton = findTranscriptButton();
+  if (!transcriptButton) {
+    throw new Error('transcript_dom_button_not_found');
+  }
+
+  transcriptButton.click();
+  const openedTranscript = await waitForTranscriptDom();
+  if (!openedTranscript) {
+    throw new Error('transcript_dom_empty');
+  }
+
+  return openedTranscript;
+}
+
 async function fetchCurrentPlayerResponse() {
   const response = await fetch(window.location.href, { credentials: 'include' });
   if (!response.ok) {
@@ -167,7 +238,7 @@ async function fetchInnertubeTranscript() {
   const params = getTranscriptParamsFromPageScripts();
 
   if (!key || !clientVersion || !params) {
-    return '';
+    throw new Error('innertube_missing_config');
   }
 
   const response = await fetch(`https://www.youtube.com/youtubei/v1/get_transcript?key=${key}`, {
@@ -191,11 +262,16 @@ async function fetchInnertubeTranscript() {
   });
 
   if (!response.ok) {
-    return '';
+    throw new Error(`innertube_http_${response.status}`);
   }
 
-  return window.ChatgptWebInjectorYoutubeTranscript
+  const transcript = window.ChatgptWebInjectorYoutubeTranscript
     .parseInnertubeTranscriptResponse(await response.json());
+  if (!transcript) {
+    throw new Error('innertube_empty_response');
+  }
+
+  return transcript;
 }
 
 function getCaptionTracks(playerResponse) {
@@ -245,6 +321,7 @@ async function getTranscript() {
     throw new Error('transcript_helpers_unavailable');
   }
 
+  const failures = [];
   const playerResponse = getPlayerResponseFromPageScripts() ||
     await fetchCurrentPlayerResponse().catch(() => null);
   const tracks = getCaptionTracks(playerResponse);
@@ -253,21 +330,37 @@ async function getTranscript() {
   });
 
   if (!track) {
-    throw new Error('no_caption_track');
+    failures.push('caption_track_missing');
+  } else {
+    try {
+      const response = await fetch(transcriptHelpers.buildCaptionUrl(track.baseUrl), { credentials: 'include' });
+      if (!response.ok) {
+        failures.push(`timedtext_http_${response.status}`);
+      } else {
+        const transcript = transcriptHelpers.parseTranscript(await response.text());
+        if (transcript) {
+          return transcript;
+        }
+        failures.push('timedtext_empty');
+      }
+    } catch (error) {
+      failures.push(error?.message ? `timedtext_error_${error.message}` : 'timedtext_error');
+    }
   }
 
-  const response = await fetch(transcriptHelpers.buildCaptionUrl(track.baseUrl), { credentials: 'include' });
-  if (!response.ok) {
-    throw new Error('caption_fetch_failed');
+  try {
+    return await fetchInnertubeTranscript();
+  } catch (error) {
+    failures.push(error?.message || 'innertube_error');
   }
 
-  const transcript = transcriptHelpers.parseTranscript(await response.text());
-  const fallbackTranscript = transcript || await fetchInnertubeTranscript();
-  if (!fallbackTranscript) {
-    throw new Error('empty_transcript');
+  try {
+    return await fetchTranscriptFromDom();
+  } catch (error) {
+    failures.push(error?.message || 'transcript_dom_error');
   }
 
-  return fallbackTranscript;
+  throw new Error(`empty_transcript: ${failures.join(', ')}`);
 }
 
 async function sendYoutubeSummary() {

--- a/src/youtube_summary.js
+++ b/src/youtube_summary.js
@@ -1,3 +1,4 @@
+(function initYoutubeSummaryContentScript() {
 const YOUTUBE_SUMMARY_BUTTON_ID = 'chatgpt-web-injector-youtube-summary';
 const YOUTUBE_SUMMARY_STATUS_ID = 'chatgpt-web-injector-youtube-status';
 const YOUTUBE_WATCH_PATH = '/watch';
@@ -199,7 +200,7 @@ async function getTranscript() {
     throw new Error('caption_fetch_failed');
   }
 
-  const transcript = transcriptHelpers.parseTranscriptXml(await response.text());
+  const transcript = transcriptHelpers.parseTranscript(await response.text());
   if (!transcript) {
     throw new Error('empty_transcript');
   }
@@ -313,3 +314,4 @@ function observePlayerControls() {
 
 observePlayerControls();
 handleNavigation();
+}());

--- a/src/youtube_summary.js
+++ b/src/youtube_summary.js
@@ -172,11 +172,33 @@ function readTranscriptFromDom() {
     }
   }
 
+  const modernSegmentNodes = Array.from(document.querySelectorAll('transcript-segment-view-model'));
+  const transcriptHelpers = window.ChatgptWebInjectorYoutubeTranscript;
+
+  for (const segment of modernSegmentNodes) {
+    const timestamp = segment.querySelector('.ytwTranscriptSegmentViewModelTimestamp')?.textContent?.trim() || '';
+    const text = Array.from(segment.querySelectorAll('span.ytAttributedStringHost'))
+      .map((node) => node.textContent?.trim() || '')
+      .filter(Boolean)
+      .join(' ')
+      .trim();
+
+    if (timestamp && text) {
+      lines.push(`[${normalizeTimestamp(timestamp)}] ${text}`);
+      continue;
+    }
+
+    const parsed = transcriptHelpers?.parseModernTranscriptSegmentText(segment.textContent || '');
+    if (parsed?.text) {
+      lines.push(`[${normalizeTimestamp(parsed.timestamp)}] ${parsed.text}`);
+    }
+  }
+
   return lines.join('\n');
 }
 
 function findTranscriptButton() {
-  const labelPattern = /show transcript|transcript|文字稿|转录|轉錄|逐字稿/i;
+  const labelPattern = /show transcript|transcript|文字稿|转录|轉錄|逐字稿|转写文稿|內容轉文字|内容转文字/i;
   const buttons = Array.from(document.querySelectorAll('button'));
 
   return buttons.find((button) => {

--- a/src/youtube_summary.js
+++ b/src/youtube_summary.js
@@ -1,0 +1,324 @@
+const YOUTUBE_SUMMARY_BUTTON_ID = 'chatgpt-web-injector-youtube-summary';
+const YOUTUBE_SUMMARY_STATUS_ID = 'chatgpt-web-injector-youtube-status';
+const YOUTUBE_WATCH_PATH = '/watch';
+const BUTTON_RETRY_MS = 750;
+const STATUS_TIMEOUT_MS = 2500;
+const DEBUG = false;
+
+let lastUrl = '';
+let mountTimer = null;
+let statusTimer = null;
+
+function log(...args) {
+  if (DEBUG) {
+    console.log('[ChatGPT Web Injector - YouTube]', ...args);
+  }
+}
+
+function isWatchPage() {
+  return window.location.hostname.endsWith('youtube.com') && window.location.pathname === YOUTUBE_WATCH_PATH;
+}
+
+function removeButton() {
+  document.getElementById(YOUTUBE_SUMMARY_BUTTON_ID)?.remove();
+  document.getElementById(YOUTUBE_SUMMARY_STATUS_ID)?.remove();
+}
+
+function showStatus(message) {
+  const button = document.getElementById(YOUTUBE_SUMMARY_BUTTON_ID);
+  if (!button) {
+    return;
+  }
+
+  clearTimeout(statusTimer);
+  document.getElementById(YOUTUBE_SUMMARY_STATUS_ID)?.remove();
+
+  const status = document.createElement('span');
+  status.id = YOUTUBE_SUMMARY_STATUS_ID;
+  status.textContent = message;
+  status.setAttribute('role', 'status');
+
+  button.insertAdjacentElement('afterend', status);
+  statusTimer = setTimeout(() => {
+    status.remove();
+  }, STATUS_TIMEOUT_MS);
+}
+
+function setButtonLoading(isLoading) {
+  const button = document.getElementById(YOUTUBE_SUMMARY_BUTTON_ID);
+  if (!button) {
+    return;
+  }
+
+  button.disabled = isLoading;
+  button.classList.toggle('is-loading', isLoading);
+  button.setAttribute('aria-busy', String(isLoading));
+}
+
+function decodeHtmlEntities(text) {
+  if (!text) {
+    return '';
+  }
+
+  const doc = new DOMParser().parseFromString(`<!doctype html><body>${text}`, 'text/html');
+  return doc.body.textContent ?? '';
+}
+
+function formatTimestamp(seconds) {
+  const totalSeconds = Math.max(0, Math.floor(Number(seconds) || 0));
+  const minutes = Math.floor(totalSeconds / 60);
+  const remainingSeconds = totalSeconds % 60;
+
+  return `${String(minutes).padStart(2, '0')}:${String(remainingSeconds).padStart(2, '0')}`;
+}
+
+function parseTranscriptXml(xml) {
+  const captions = [];
+  const textNodePattern = /<text\b([^>]*)>([\s\S]*?)<\/text>/g;
+  let match = textNodePattern.exec(xml);
+
+  while (match) {
+    const [, attrs, rawText] = match;
+    const start = attrs.match(/\bstart="([^"]+)"/)?.[1] ?? '0';
+    const text = decodeHtmlEntities(rawText.replaceAll('\n', ' ')).trim();
+
+    if (text) {
+      captions.push(`[${formatTimestamp(start)}] ${text}`);
+    }
+
+    match = textNodePattern.exec(xml);
+  }
+
+  return captions.join('\n');
+}
+
+function extractBalancedJson(text, marker) {
+  const markerIndex = text.indexOf(marker);
+  if (markerIndex < 0) {
+    return null;
+  }
+
+  const start = text.indexOf('{', markerIndex + marker.length);
+  if (start < 0) {
+    return null;
+  }
+
+  let depth = 0;
+  let inString = false;
+  let isEscaped = false;
+
+  for (let i = start; i < text.length; i += 1) {
+    const char = text[i];
+
+    if (inString) {
+      if (isEscaped) {
+        isEscaped = false;
+      } else if (char === '\\') {
+        isEscaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+    } else if (char === '{') {
+      depth += 1;
+    } else if (char === '}') {
+      depth -= 1;
+      if (depth === 0) {
+        return text.slice(start, i + 1);
+      }
+    }
+  }
+
+  return null;
+}
+
+function getPlayerResponseFromHtml(html) {
+  const json = extractBalancedJson(html, 'ytInitialPlayerResponse');
+  if (!json) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(json);
+  } catch (error) {
+    log('Failed to parse player response:', error);
+    return null;
+  }
+}
+
+function getPlayerResponseFromPageScripts() {
+  for (const script of document.scripts) {
+    const response = getPlayerResponseFromHtml(script.textContent || '');
+    if (response) {
+      return response;
+    }
+  }
+  return null;
+}
+
+async function fetchCurrentPlayerResponse() {
+  const response = await fetch(window.location.href, { credentials: 'include' });
+  if (!response.ok) {
+    throw new Error('watch_page_fetch_failed');
+  }
+
+  return getPlayerResponseFromHtml(await response.text());
+}
+
+function getCaptionTracks(playerResponse) {
+  return playerResponse?.captions?.playerCaptionsTracklistRenderer?.captionTracks ?? [];
+}
+
+function getActiveCaptionLanguageCode() {
+  const subtitlesButton = document.querySelector('.ytp-subtitles-button');
+  const isPressed = subtitlesButton?.getAttribute('aria-pressed') === 'true';
+  if (!isPressed) {
+    return '';
+  }
+
+  for (let i = 0; i < window.localStorage.length; i += 1) {
+    const key = window.localStorage.key(i);
+    const value = key ? window.localStorage.getItem(key) : '';
+    const languageCode = value?.match(/"languageCode"\s*:\s*"([^"]+)"/)?.[1];
+    if (languageCode) {
+      return languageCode;
+    }
+  }
+
+  return '';
+}
+
+function chooseCaptionTrack(tracks, activeLanguageCode) {
+  const readableTracks = tracks.filter((track) => track?.baseUrl);
+  if (readableTracks.length === 0) {
+    return null;
+  }
+
+  if (activeLanguageCode) {
+    const activeTrack = readableTracks.find((track) => track.languageCode === activeLanguageCode);
+    if (activeTrack) {
+      return activeTrack;
+    }
+  }
+
+  const browserLanguage = navigator.language?.split('-')[0];
+  return readableTracks.find((track) => track.isDefault) ??
+    readableTracks.find((track) => track.languageCode === browserLanguage) ??
+    readableTracks[0];
+}
+
+async function getTranscript() {
+  const playerResponse = await fetchCurrentPlayerResponse().catch(() => getPlayerResponseFromPageScripts());
+  const tracks = getCaptionTracks(playerResponse);
+  const track = chooseCaptionTrack(tracks, getActiveCaptionLanguageCode());
+
+  if (!track) {
+    throw new Error('no_caption_track');
+  }
+
+  const response = await fetch(track.baseUrl, { credentials: 'include' });
+  if (!response.ok) {
+    throw new Error('caption_fetch_failed');
+  }
+
+  const transcript = parseTranscriptXml(await response.text());
+  if (!transcript) {
+    throw new Error('empty_transcript');
+  }
+
+  return transcript;
+}
+
+async function sendYoutubeSummary() {
+  setButtonLoading(true);
+
+  try {
+    const transcript = await getTranscript();
+    const payload = {
+      title: document.querySelector('h1.ytd-watch-metadata')?.textContent?.trim() || document.title,
+      url: window.location.href,
+      transcript,
+    };
+
+    if (typeof chrome === 'undefined' || !chrome.runtime?.sendMessage) {
+      showStatus('Extension unavailable');
+      return;
+    }
+
+    try {
+      chrome.runtime.sendMessage({ type: 'YOUTUBE_SUMMARY_SEND', payload });
+    } catch (err) {
+      console.warn('[ChatGPT Web Injector] YouTube summary message failed:', err);
+      showStatus('Refresh this tab');
+      return;
+    }
+
+    showStatus('Sent to ChatGPT');
+  } catch (error) {
+    console.warn('[ChatGPT Web Injector] YouTube summary failed:', error);
+    showStatus('No readable captions');
+  } finally {
+    setButtonLoading(false);
+  }
+}
+
+function createButton() {
+  const button = document.createElement('button');
+  button.id = YOUTUBE_SUMMARY_BUTTON_ID;
+  button.type = 'button';
+  button.title = 'Summarize with ChatGPT';
+  button.setAttribute('aria-label', 'Summarize with ChatGPT');
+  button.textContent = 'AI';
+  button.addEventListener('click', (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    sendYoutubeSummary();
+  });
+  return button;
+}
+
+function mountButton() {
+  clearTimeout(mountTimer);
+
+  if (!isWatchPage()) {
+    removeButton();
+    return;
+  }
+
+  if (document.getElementById(YOUTUBE_SUMMARY_BUTTON_ID)) {
+    return;
+  }
+
+  const subtitlesButton = document.querySelector('.ytp-subtitles-button');
+  if (!subtitlesButton?.parentElement) {
+    mountTimer = setTimeout(mountButton, BUTTON_RETRY_MS);
+    return;
+  }
+
+  subtitlesButton.insertAdjacentElement('afterend', createButton());
+}
+
+function handleNavigation() {
+  if (lastUrl === window.location.href) {
+    mountButton();
+    return;
+  }
+
+  lastUrl = window.location.href;
+  removeButton();
+  mountButton();
+}
+
+document.addEventListener('yt-navigate-finish', handleNavigation, true);
+document.addEventListener('yt-page-data-updated', handleNavigation, true);
+
+const observer = new MutationObserver(() => {
+  mountButton();
+});
+
+observer.observe(document.documentElement, { childList: true, subtree: true });
+handleNavigation();

--- a/src/youtube_transcript.js
+++ b/src/youtube_transcript.js
@@ -1,70 +1,80 @@
-export function chooseCaptionTrack(tracks, options = {}) {
-  if (!Array.isArray(tracks) || tracks.length === 0) {
-    return null;
-  }
-
-  const readableTracks = tracks.filter((track) => track?.baseUrl);
-  if (readableTracks.length === 0) {
-    return null;
-  }
-
-  const activeLanguageCode = options.activeLanguageCode;
-  if (activeLanguageCode) {
-    const activeTrack = readableTracks.find((track) => track.languageCode === activeLanguageCode);
-    if (activeTrack) {
-      return activeTrack;
-    }
-  }
-
-  return readableTracks.find((track) => track.isDefault) ?? readableTracks[0];
-}
-
-function decodeHtmlEntities(text) {
-  if (!text) {
-    return '';
-  }
-
-  if (typeof DOMParser !== 'undefined') {
-    const doc = new DOMParser().parseFromString(`<!doctype html><body>${text}`, 'text/html');
-    return doc.body.textContent ?? '';
-  }
-
-  return text
-    .replaceAll('&amp;', '&')
-    .replaceAll('&lt;', '<')
-    .replaceAll('&gt;', '>')
-    .replaceAll('&quot;', '"')
-    .replaceAll('&#39;', "'");
-}
-
-function formatTimestamp(seconds) {
-  const totalSeconds = Math.max(0, Math.floor(Number(seconds) || 0));
-  const minutes = Math.floor(totalSeconds / 60);
-  const remainingSeconds = totalSeconds % 60;
-
-  return `${String(minutes).padStart(2, '0')}:${String(remainingSeconds).padStart(2, '0')}`;
-}
-
-export function parseTranscriptXml(xml) {
-  if (!xml || typeof xml !== 'string') {
-    return '';
-  }
-
-  const captions = [];
-  const textNodePattern = /<text\b([^>]*)>([\s\S]*?)<\/text>/g;
-  let match = textNodePattern.exec(xml);
-
-  while (match) {
-    const [, attrs, rawText] = match;
-    const start = attrs.match(/\bstart="([^"]+)"/)?.[1] ?? '0';
-    const text = decodeHtmlEntities(rawText.replaceAll('\n', ' ')).trim();
-
-    if (text) {
-      captions.push(`[${formatTimestamp(start)}] ${text}`);
+(function initYoutubeTranscriptHelpers(globalScope) {
+  function chooseCaptionTrack(tracks, options = {}) {
+    if (!Array.isArray(tracks) || tracks.length === 0) {
+      return null;
     }
 
-    match = textNodePattern.exec(xml);
+    const readableTracks = tracks.filter((track) => track?.baseUrl);
+    if (readableTracks.length === 0) {
+      return null;
+    }
+
+    const activeLanguageCode = options.activeLanguageCode;
+    if (activeLanguageCode) {
+      const activeTrack = readableTracks.find((track) => track.languageCode === activeLanguageCode);
+      if (activeTrack) {
+        return activeTrack;
+      }
+    }
+
+    const browserLanguage = globalScope.navigator?.language?.split('-')[0];
+    return readableTracks.find((track) => track.isDefault) ??
+      readableTracks.find((track) => track.languageCode === browserLanguage) ??
+      readableTracks[0];
   }
 
-  return captions.join('\n');
-}
+  function decodeHtmlEntities(text) {
+    if (!text) {
+      return '';
+    }
+
+    if (typeof globalScope.DOMParser !== 'undefined') {
+      const doc = new globalScope.DOMParser().parseFromString(`<!doctype html><body>${text}`, 'text/html');
+      return doc.body.textContent ?? '';
+    }
+
+    return text
+      .replaceAll('&amp;', '&')
+      .replaceAll('&lt;', '<')
+      .replaceAll('&gt;', '>')
+      .replaceAll('&quot;', '"')
+      .replaceAll('&#39;', "'");
+  }
+
+  function formatTimestamp(seconds) {
+    const totalSeconds = Math.max(0, Math.floor(Number(seconds) || 0));
+    const minutes = Math.floor(totalSeconds / 60);
+    const remainingSeconds = totalSeconds % 60;
+
+    return `${String(minutes).padStart(2, '0')}:${String(remainingSeconds).padStart(2, '0')}`;
+  }
+
+  function parseTranscriptXml(xml) {
+    if (!xml || typeof xml !== 'string') {
+      return '';
+    }
+
+    const captions = [];
+    const textNodePattern = /<text\b([^>]*)>([\s\S]*?)<\/text>/g;
+    let match = textNodePattern.exec(xml);
+
+    while (match) {
+      const [, attrs, rawText] = match;
+      const start = attrs.match(/\bstart="([^"]+)"/)?.[1] ?? '0';
+      const text = decodeHtmlEntities(rawText.replaceAll('\n', ' ')).trim();
+
+      if (text) {
+        captions.push(`[${formatTimestamp(start)}] ${text}`);
+      }
+
+      match = textNodePattern.exec(xml);
+    }
+
+    return captions.join('\n');
+  }
+
+  globalScope.ChatgptWebInjectorYoutubeTranscript = {
+    chooseCaptionTrack,
+    parseTranscriptXml,
+  };
+}(globalThis));

--- a/src/youtube_transcript.js
+++ b/src/youtube_transcript.js
@@ -141,6 +141,58 @@
     return captions.join('\n');
   }
 
+  function textFromRuns(textObject) {
+    if (Array.isArray(textObject?.runs)) {
+      return textObject.runs.map((run) => run?.text ?? '').join('').trim();
+    }
+    return (textObject?.simpleText ?? '').trim();
+  }
+
+  function walkObject(value, visitor) {
+    if (!value || typeof value !== 'object') {
+      return;
+    }
+
+    visitor(value);
+
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        walkObject(item, visitor);
+      }
+      return;
+    }
+
+    for (const item of Object.values(value)) {
+      walkObject(item, visitor);
+    }
+  }
+
+  function parseInnertubeTranscriptResponse(response) {
+    const segments = [];
+
+    walkObject(response, (node) => {
+      const segment = node.transcriptSegmentRenderer;
+      if (!segment) {
+        return;
+      }
+
+      const text = textFromRuns(segment.snippet);
+      if (!text) {
+        return;
+      }
+
+      segments.push({
+        startMs: Number(segment.startMs) || 0,
+        text,
+      });
+    });
+
+    return segments
+      .sort((a, b) => a.startMs - b.startMs)
+      .map((segment) => `[${formatTimestamp(segment.startMs / 1000)}] ${segment.text}`)
+      .join('\n');
+  }
+
   function parseTranscript(text) {
     if (!text || typeof text !== 'string') {
       return '';
@@ -167,6 +219,7 @@
   globalScope.ChatgptWebInjectorYoutubeTranscript = {
     buildCaptionUrl,
     chooseCaptionTrack,
+    parseInnertubeTranscriptResponse,
     parseTranscript,
     parseTranscriptXml,
   };

--- a/src/youtube_transcript.js
+++ b/src/youtube_transcript.js
@@ -1,0 +1,70 @@
+export function chooseCaptionTrack(tracks, options = {}) {
+  if (!Array.isArray(tracks) || tracks.length === 0) {
+    return null;
+  }
+
+  const readableTracks = tracks.filter((track) => track?.baseUrl);
+  if (readableTracks.length === 0) {
+    return null;
+  }
+
+  const activeLanguageCode = options.activeLanguageCode;
+  if (activeLanguageCode) {
+    const activeTrack = readableTracks.find((track) => track.languageCode === activeLanguageCode);
+    if (activeTrack) {
+      return activeTrack;
+    }
+  }
+
+  return readableTracks.find((track) => track.isDefault) ?? readableTracks[0];
+}
+
+function decodeHtmlEntities(text) {
+  if (!text) {
+    return '';
+  }
+
+  if (typeof DOMParser !== 'undefined') {
+    const doc = new DOMParser().parseFromString(`<!doctype html><body>${text}`, 'text/html');
+    return doc.body.textContent ?? '';
+  }
+
+  return text
+    .replaceAll('&amp;', '&')
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>')
+    .replaceAll('&quot;', '"')
+    .replaceAll('&#39;', "'");
+}
+
+function formatTimestamp(seconds) {
+  const totalSeconds = Math.max(0, Math.floor(Number(seconds) || 0));
+  const minutes = Math.floor(totalSeconds / 60);
+  const remainingSeconds = totalSeconds % 60;
+
+  return `${String(minutes).padStart(2, '0')}:${String(remainingSeconds).padStart(2, '0')}`;
+}
+
+export function parseTranscriptXml(xml) {
+  if (!xml || typeof xml !== 'string') {
+    return '';
+  }
+
+  const captions = [];
+  const textNodePattern = /<text\b([^>]*)>([\s\S]*?)<\/text>/g;
+  let match = textNodePattern.exec(xml);
+
+  while (match) {
+    const [, attrs, rawText] = match;
+    const start = attrs.match(/\bstart="([^"]+)"/)?.[1] ?? '0';
+    const text = decodeHtmlEntities(rawText.replaceAll('\n', ' ')).trim();
+
+    if (text) {
+      captions.push(`[${formatTimestamp(start)}] ${text}`);
+    }
+
+    match = textNodePattern.exec(xml);
+  }
+
+  return captions.join('\n');
+}

--- a/src/youtube_transcript.js
+++ b/src/youtube_transcript.js
@@ -193,6 +193,19 @@
       .join('\n');
   }
 
+  function parseModernTranscriptSegmentText(rawText) {
+    const normalized = (rawText || '').trim().replace(/\s+/g, ' ');
+    const match = normalized.match(/^(\d{1,2}:\d{2})(?:(?:\d+)?(?:秒钟|秒|second(?:s)?|分钟|minute(?:s)?))?(.*)$/i);
+    if (!match) {
+      return { timestamp: '', text: normalized };
+    }
+
+    return {
+      timestamp: match[1],
+      text: match[2].trim(),
+    };
+  }
+
   function parseTranscript(text) {
     if (!text || typeof text !== 'string') {
       return '';
@@ -220,6 +233,7 @@
     buildCaptionUrl,
     chooseCaptionTrack,
     parseInnertubeTranscriptResponse,
+    parseModernTranscriptSegmentText,
     parseTranscript,
     parseTranscriptXml,
   };

--- a/src/youtube_transcript.js
+++ b/src/youtube_transcript.js
@@ -73,8 +73,50 @@
     return captions.join('\n');
   }
 
+  function parseTranscriptJson(json) {
+    let data;
+    try {
+      data = JSON.parse(json);
+    } catch (_error) {
+      return '';
+    }
+
+    if (!Array.isArray(data.events)) {
+      return '';
+    }
+
+    return data.events
+      .map((event) => {
+        const text = Array.isArray(event.segs)
+          ? event.segs.map((segment) => segment?.utf8 ?? '').join('').trim()
+          : '';
+
+        if (!text) {
+          return '';
+        }
+
+        return `[${formatTimestamp((event.tStartMs ?? 0) / 1000)}] ${text}`;
+      })
+      .filter(Boolean)
+      .join('\n');
+  }
+
+  function parseTranscript(text) {
+    if (!text || typeof text !== 'string') {
+      return '';
+    }
+
+    const trimmed = text.trim();
+    if (trimmed.startsWith('{')) {
+      return parseTranscriptJson(trimmed);
+    }
+
+    return parseTranscriptXml(trimmed);
+  }
+
   globalScope.ChatgptWebInjectorYoutubeTranscript = {
     chooseCaptionTrack,
+    parseTranscript,
     parseTranscriptXml,
   };
 }(globalThis));

--- a/src/youtube_transcript.js
+++ b/src/youtube_transcript.js
@@ -49,6 +49,17 @@
     return `${String(minutes).padStart(2, '0')}:${String(remainingSeconds).padStart(2, '0')}`;
   }
 
+  function parseTimestamp(timestamp) {
+    const parts = timestamp.split(':').map(Number);
+    if (parts.length === 3) {
+      return (parts[0] * 3600) + (parts[1] * 60) + parts[2];
+    }
+    if (parts.length === 2) {
+      return (parts[0] * 60) + parts[1];
+    }
+    return Number(timestamp) || 0;
+  }
+
   function parseTranscriptXml(xml) {
     if (!xml || typeof xml !== 'string') {
       return '';
@@ -101,6 +112,35 @@
       .join('\n');
   }
 
+  function parseTranscriptVtt(vtt) {
+    const lines = vtt.split(/\r?\n/);
+    const captions = [];
+
+    for (let i = 0; i < lines.length; i += 1) {
+      const timing = lines[i].match(/^(\d{2}:\d{2}(?::\d{2})?\.\d{3})\s+-->/);
+      if (!timing) {
+        continue;
+      }
+
+      const textLines = [];
+      i += 1;
+      while (i < lines.length && lines[i].trim()) {
+        const line = lines[i].trim();
+        if (!line.startsWith('<')) {
+          textLines.push(line.replace(/<[^>]+>/g, ''));
+        }
+        i += 1;
+      }
+
+      const text = decodeHtmlEntities(textLines.join(' ')).trim();
+      if (text) {
+        captions.push(`[${formatTimestamp(parseTimestamp(timing[1]))}] ${text}`);
+      }
+    }
+
+    return captions.join('\n');
+  }
+
   function parseTranscript(text) {
     if (!text || typeof text !== 'string') {
       return '';
@@ -111,10 +151,21 @@
       return parseTranscriptJson(trimmed);
     }
 
+    if (trimmed.startsWith('WEBVTT')) {
+      return parseTranscriptVtt(trimmed);
+    }
+
     return parseTranscriptXml(trimmed);
   }
 
+  function buildCaptionUrl(baseUrl) {
+    const url = new URL(baseUrl);
+    url.searchParams.set('fmt', 'json3');
+    return url.toString();
+  }
+
   globalScope.ChatgptWebInjectorYoutubeTranscript = {
+    buildCaptionUrl,
     chooseCaptionTrack,
     parseTranscript,
     parseTranscriptXml,

--- a/tests/content_script_globals.test.js
+++ b/tests/content_script_globals.test.js
@@ -1,0 +1,41 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
+import { JSDOM } from 'jsdom';
+
+test('YouTube summary content scripts do not collide with selection tooltip globals', () => {
+  const dom = new JSDOM('<html><body></body></html>', { url: 'https://www.youtube.com/watch?v=abc123' });
+  const context = {
+    chrome: { runtime: { sendMessage() {} } },
+    console,
+    document: dom.window.document,
+    globalThis: null,
+    localStorage: dom.window.localStorage,
+    location: dom.window.location,
+    MutationObserver: class {
+      disconnect() {}
+      observe() {}
+    },
+    navigator: dom.window.navigator,
+    setTimeout() {
+      return 0;
+    },
+    clearTimeout() {},
+    window: dom.window,
+  };
+
+  context.globalThis = context;
+  context.window = context;
+
+  for (const path of [
+    '../src/youtube_transcript.js',
+    '../src/youtube_summary.js',
+    '../src/selection_tooltip.js',
+  ]) {
+    const source = readFileSync(new URL(path, import.meta.url), 'utf8');
+    assert.doesNotThrow(() => {
+      vm.runInNewContext(source, context);
+    });
+  }
+});

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -1,0 +1,91 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  DEFAULT_YOUTUBE_SUMMARY_TEMPLATE,
+  loadYoutubeSummaryTemplate,
+  resetYoutubeSummaryTemplate,
+  saveYoutubeSummaryTemplate,
+} from '../src/storage.js';
+
+function installChromeStorage(initialData = {}) {
+  const previousChrome = globalThis.chrome;
+  const store = { ...initialData };
+
+  globalThis.chrome = {
+    storage: {
+      sync: {
+        async get(keys) {
+          const result = {};
+          for (const key of keys) {
+            if (Object.hasOwn(store, key)) {
+              result[key] = store[key];
+            }
+          }
+          return result;
+        },
+        async set(values) {
+          Object.assign(store, values);
+        },
+      },
+    },
+  };
+
+  return {
+    store,
+    restore() {
+      globalThis.chrome = previousChrome;
+    },
+  };
+}
+
+test('loadYoutubeSummaryTemplate falls back to the default template', async () => {
+  const chromeStorage = installChromeStorage();
+
+  try {
+    const template = await loadYoutubeSummaryTemplate();
+
+    assert.equal(template, DEFAULT_YOUTUBE_SUMMARY_TEMPLATE);
+  } finally {
+    chromeStorage.restore();
+  }
+});
+
+test('loadYoutubeSummaryTemplate treats a blank saved template as the YouTube default', async () => {
+  const chromeStorage = installChromeStorage({ youtubeSummaryTemplate: '   \n' });
+
+  try {
+    const template = await loadYoutubeSummaryTemplate();
+
+    assert.equal(template, DEFAULT_YOUTUBE_SUMMARY_TEMPLATE);
+  } finally {
+    chromeStorage.restore();
+  }
+});
+
+test('saveYoutubeSummaryTemplate persists a separate YouTube template', async () => {
+  const chromeStorage = installChromeStorage();
+
+  try {
+    await saveYoutubeSummaryTemplate('Summarize {{transcript}}');
+    const template = await loadYoutubeSummaryTemplate();
+
+    assert.equal(template, 'Summarize {{transcript}}');
+    assert.equal(chromeStorage.store.youtubeSummaryTemplate, 'Summarize {{transcript}}');
+  } finally {
+    chromeStorage.restore();
+  }
+});
+
+test('resetYoutubeSummaryTemplate restores the default YouTube template', async () => {
+  const chromeStorage = installChromeStorage({ youtubeSummaryTemplate: 'Custom {{transcript}}' });
+
+  try {
+    const template = await resetYoutubeSummaryTemplate();
+
+    assert.equal(template, DEFAULT_YOUTUBE_SUMMARY_TEMPLATE);
+    assert.equal(chromeStorage.store.youtubeSummaryTemplate, DEFAULT_YOUTUBE_SUMMARY_TEMPLATE);
+  } finally {
+    chromeStorage.restore();
+  }
+});

--- a/tests/template.test.js
+++ b/tests/template.test.js
@@ -29,3 +29,12 @@ test('renderTemplate keeps empty selection as empty string', () => {
 
   assert.equal(output, 'Body:\n');
 });
+
+test('renderTemplate replaces transcript for YouTube summary templates', () => {
+  const output = renderTemplate('Video: {{title}}\nTranscript:\n{{transcript}}', {
+    title: 'Example Video',
+    transcript: 'First caption line.\nSecond caption line.',
+  });
+
+  assert.equal(output, 'Video: Example Video\nTranscript:\nFirst caption line.\nSecond caption line.');
+});

--- a/tests/youtube_transcript.test.js
+++ b/tests/youtube_transcript.test.js
@@ -1,12 +1,24 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
 
-import {
-  chooseCaptionTrack,
-  parseTranscriptXml,
-} from '../src/youtube_transcript.js';
+function loadHelpers(options = {}) {
+  const context = {
+    DOMParser: options.DOMParser,
+    navigator: options.navigator ?? { language: 'en-US' },
+  };
+
+  context.globalThis = context;
+
+  const source = readFileSync(new URL('../src/youtube_transcript.js', import.meta.url), 'utf8');
+  vm.runInNewContext(source, context);
+
+  return context.ChatgptWebInjectorYoutubeTranscript;
+}
 
 test('chooseCaptionTrack prefers the active caption language', () => {
+  const { chooseCaptionTrack } = loadHelpers();
   const tracks = [
     { languageCode: 'en', baseUrl: 'https://example.com/en' },
     { languageCode: 'ko', baseUrl: 'https://example.com/ko' },
@@ -16,6 +28,7 @@ test('chooseCaptionTrack prefers the active caption language', () => {
 });
 
 test('chooseCaptionTrack falls back to default and then first readable track', () => {
+  const { chooseCaptionTrack } = loadHelpers();
   const tracks = [
     { languageCode: 'en', baseUrl: 'https://example.com/en' },
     { languageCode: 'ja', baseUrl: 'https://example.com/ja', isDefault: true },
@@ -28,7 +41,18 @@ test('chooseCaptionTrack falls back to default and then first readable track', (
   });
 });
 
+test('chooseCaptionTrack can fall back to the browser language before first track', () => {
+  const { chooseCaptionTrack } = loadHelpers({ navigator: { language: 'ko-KR' } });
+  const tracks = [
+    { languageCode: 'en', baseUrl: 'https://example.com/en' },
+    { languageCode: 'ko', baseUrl: 'https://example.com/ko' },
+  ];
+
+  assert.deepEqual(chooseCaptionTrack(tracks, { activeLanguageCode: 'de' }), tracks[1]);
+});
+
 test('parseTranscriptXml decodes captions into timestamped text', () => {
+  const { parseTranscriptXml } = loadHelpers();
   const xml = `
     <transcript>
       <text start="0.4" dur="1.2">Hello &amp; welcome</text>

--- a/tests/youtube_transcript.test.js
+++ b/tests/youtube_transcript.test.js
@@ -99,3 +99,46 @@ test('buildCaptionUrl requests json3 format without dropping existing params', (
     'https://example.com/api?lang=en&fmt=json3'
   );
 });
+
+test('parseInnertubeTranscriptResponse decodes transcript panel segments', () => {
+  const { parseInnertubeTranscriptResponse } = loadHelpers();
+  const response = {
+    actions: [
+      {
+        updateEngagementPanelAction: {
+          content: {
+            transcriptRenderer: {
+              content: {
+                transcriptSearchPanelRenderer: {
+                  body: {
+                    transcriptSegmentListRenderer: {
+                      initialSegments: [
+                        {
+                          transcriptSegmentRenderer: {
+                            startMs: '400',
+                            snippet: { runs: [{ text: 'Hello ' }, { text: 'world' }] },
+                          },
+                        },
+                        {
+                          transcriptSegmentRenderer: {
+                            startMs: '65200',
+                            snippet: { simpleText: 'Second line' },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    ],
+  };
+
+  assert.equal(
+    parseInnertubeTranscriptResponse(response),
+    '[00:00] Hello world\n[01:05] Second line'
+  );
+});

--- a/tests/youtube_transcript.test.js
+++ b/tests/youtube_transcript.test.js
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  chooseCaptionTrack,
+  parseTranscriptXml,
+} from '../src/youtube_transcript.js';
+
+test('chooseCaptionTrack prefers the active caption language', () => {
+  const tracks = [
+    { languageCode: 'en', baseUrl: 'https://example.com/en' },
+    { languageCode: 'ko', baseUrl: 'https://example.com/ko' },
+  ];
+
+  assert.deepEqual(chooseCaptionTrack(tracks, { activeLanguageCode: 'ko' }), tracks[1]);
+});
+
+test('chooseCaptionTrack falls back to default and then first readable track', () => {
+  const tracks = [
+    { languageCode: 'en', baseUrl: 'https://example.com/en' },
+    { languageCode: 'ja', baseUrl: 'https://example.com/ja', isDefault: true },
+  ];
+
+  assert.deepEqual(chooseCaptionTrack(tracks, { activeLanguageCode: 'de' }), tracks[1]);
+  assert.deepEqual(chooseCaptionTrack([{ languageCode: 'en', baseUrl: 'https://example.com/en' }]), {
+    languageCode: 'en',
+    baseUrl: 'https://example.com/en',
+  });
+});
+
+test('parseTranscriptXml decodes captions into timestamped text', () => {
+  const xml = `
+    <transcript>
+      <text start="0.4" dur="1.2">Hello &amp; welcome</text>
+      <text start="65.2" dur="2">Second line</text>
+    </transcript>
+  `;
+
+  assert.equal(parseTranscriptXml(xml), '[00:00] Hello & welcome\n[01:05] Second line');
+});

--- a/tests/youtube_transcript.test.js
+++ b/tests/youtube_transcript.test.js
@@ -7,6 +7,7 @@ function loadHelpers(options = {}) {
   const context = {
     DOMParser: options.DOMParser,
     navigator: options.navigator ?? { language: 'en-US' },
+    URL,
   };
 
   context.globalThis = context;
@@ -74,4 +75,27 @@ test('parseTranscript decodes YouTube json3 captions into timestamped text', () 
   });
 
   assert.equal(parseTranscript(json), '[00:00] Hello world\n[01:05] Second line');
+});
+
+test('parseTranscript decodes WebVTT captions into timestamped text', () => {
+  const { parseTranscript } = loadHelpers();
+  const vtt = `WEBVTT
+
+00:00:00.400 --> 00:00:01.600
+Hello world
+
+00:01:05.200 --> 00:01:07.200
+Second line
+`;
+
+  assert.equal(parseTranscript(vtt), '[00:00] Hello world\n[01:05] Second line');
+});
+
+test('buildCaptionUrl requests json3 format without dropping existing params', () => {
+  const { buildCaptionUrl } = loadHelpers();
+
+  assert.equal(
+    buildCaptionUrl('https://example.com/api?lang=en&fmt=srv3'),
+    'https://example.com/api?lang=en&fmt=json3'
+  );
 });

--- a/tests/youtube_transcript.test.js
+++ b/tests/youtube_transcript.test.js
@@ -142,3 +142,12 @@ test('parseInnertubeTranscriptResponse decodes transcript panel segments', () =>
     '[00:00] Hello world\n[01:05] Second line'
   );
 });
+
+test('parseModernTranscriptSegmentText separates new YouTube transcript segment text', () => {
+  const { parseModernTranscriptSegmentText } = loadHelpers();
+
+  assert.equal(
+    JSON.stringify(parseModernTranscriptSegmentText('0:055秒钟You have to fight for the bill.')),
+    JSON.stringify({ timestamp: '0:05', text: 'You have to fight for the bill.' })
+  );
+});

--- a/tests/youtube_transcript.test.js
+++ b/tests/youtube_transcript.test.js
@@ -62,3 +62,16 @@ test('parseTranscriptXml decodes captions into timestamped text', () => {
 
   assert.equal(parseTranscriptXml(xml), '[00:00] Hello & welcome\n[01:05] Second line');
 });
+
+test('parseTranscript decodes YouTube json3 captions into timestamped text', () => {
+  const { parseTranscript } = loadHelpers();
+  const json = JSON.stringify({
+    events: [
+      { tStartMs: 400, segs: [{ utf8: 'Hello ' }, { utf8: 'world' }] },
+      { tStartMs: 65200, segs: [{ utf8: 'Second line' }] },
+      { tStartMs: 70000 },
+    ],
+  });
+
+  assert.equal(parseTranscript(json), '[00:00] Hello world\n[01:05] Second line');
+});


### PR DESCRIPTION
## Summary
- Add a YouTube-only AI summary button near the player captions control.
- Extract readable caption transcripts and send a dedicated YouTube Summary prompt to ChatGPT automatically.
- Add separate options-page editing and storage for the YouTube Summary template.

## Files
- src/youtube_summary.js, src/youtube_summary.css
- src/service_worker.js, src/storage.js, src/template.js
- options/options.html, options/options.js, options/options.css
- tests/storage.test.js, tests/youtube_transcript.test.js, tests/template.test.js

## Verification
- npm test
- node --check src/service_worker.js
- node --check src/youtube_summary.js
- node --check src/youtube_transcript.js
- node --check src/storage.js
- node --check src/template.js
- node --check options/options.js

closes #26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI button on YouTube watch pages to summarize video captions.
  * YouTube Summary Template editor in Options for custom prompts.
  * Automatic transcript extraction, parsing, and timestamped formatting for summaries.
  * Extension loads YouTube-specific scripts/styles when visiting YouTube pages.

* **Documentation**
  * Added implementation plan for the YouTube caption summary feature.

* **Tests**
  * New unit and storage tests for template handling and transcript parsing.

* **Style**
  * Adjusted options UI spacing for clearer section layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->