### PR TITLE
feat: add YouTube template popup shortcut

### DIFF
--- a/options/options.html
+++ b/options/options.html
@@ -11,7 +11,7 @@
       <h1>ChatGPT Web Injector</h1>
       <p class="subtitle">Manage your prompt templates. The active template is used by the floating button and as the default send action.</p>
 
-      <section id="youtube-summary-template" class="settings-section">
+      <section class="settings-section">
         <div class="templates-header">
           <h2>Templates</h2>
           <button id="add-template" type="button" class="btn-secondary">+ New template</button>
@@ -37,7 +37,7 @@
         </div>
       </section>
 
-      <section class="settings-section">
+      <section id="youtube-summary-template" class="settings-section">
         <div class="templates-header">
           <h2>YouTube Summary Template</h2>
           <button id="reset-youtube-tpl" type="button" class="btn-secondary">Reset</button>

--- a/options/options.html
+++ b/options/options.html
@@ -11,7 +11,7 @@
       <h1>ChatGPT Web Injector</h1>
       <p class="subtitle">Manage your prompt templates. The active template is used by the floating button and as the default send action.</p>
 
-      <section class="settings-section">
+      <section id="youtube-summary-template" class="settings-section">
         <div class="templates-header">
           <h2>Templates</h2>
           <button id="add-template" type="button" class="btn-secondary">+ New template</button>

--- a/options/options.js
+++ b/options/options.js
@@ -202,6 +202,11 @@ async function init() {
   state = await loadTemplates();
   youtubeBodyInput.value = await loadYoutubeSummaryTemplate();
   renderList();
+
+  if (window.location.hash === '#youtube-summary-template') {
+    document.getElementById('youtube-summary-template')?.scrollIntoView({ block: 'start' });
+    youtubeBodyInput.focus();
+  }
 }
 
 init().catch((err) => {

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -81,6 +81,10 @@ h1 {
 .footer {
   border-top: 1px solid #f0f0f0;
   padding: 8px 14px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 7px;
 }
 
 .manage-link {

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -12,6 +12,7 @@
       <ul id="template-list" class="template-list" role="listbox" aria-label="Templates"></ul>
       <div class="footer">
         <button id="manage-btn" type="button" class="manage-link">Manage templates</button>
+        <button id="youtube-template-btn" type="button" class="manage-link">Edit YouTube summary</button>
       </div>
     </div>
     <script type="module" src="./popup.js"></script>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -2,6 +2,7 @@ import { loadTemplates, saveTemplates } from '../src/storage.js';
 
 const listEl = document.getElementById('template-list');
 const manageBtn = document.getElementById('manage-btn');
+const youtubeTemplateBtn = document.getElementById('youtube-template-btn');
 
 let state = { templates: [], activeTemplateId: '' };
 
@@ -79,6 +80,11 @@ listEl.addEventListener('keydown', (e) => {
 
 manageBtn.addEventListener('click', () => {
   chrome.tabs.create({ url: chrome.runtime.getURL('options/options.html') });
+  window.close();
+});
+
+youtubeTemplateBtn.addEventListener('click', () => {
+  chrome.tabs.create({ url: chrome.runtime.getURL('options/options.html#youtube-summary-template') });
   window.close();
 });
 


### PR DESCRIPTION
## Summary
- Add a distinct popup shortcut for editing the YouTube Summary Template.
- Open options with a YouTube template hash target.
- Scroll and focus the YouTube template editor when opened through the shortcut.

## Files
- popup/popup.html
- popup/popup.js
- popup/popup.css
- options/options.html
- options/options.js

## Verification
- node --check popup/popup.js
- node --check options/options.js
- npm test

closes #28