### PR TITLE
feat: improve YouTube transcript actions

### DIFF
--- a/src/chatgpt_content.js
+++ b/src/chatgpt_content.js
@@ -1,6 +1,7 @@
 export async function runChatgptSendFlow(prompt, options = {}) {
   const maxAttempts = Number.isFinite(options.maxAttempts) ? options.maxAttempts : 20;
   const intervalMs = Number.isFinite(options.intervalMs) ? options.intervalMs : 250;
+  const preferTemporaryChat = options.preferTemporaryChat === true;
   const fallbackId = 'chatgpt-web-injector-fallback';
 
   const inputSelectors = ['textarea', "[contenteditable='true']", "div[role='textbox']"];
@@ -33,6 +34,34 @@ export async function runChatgptSendFlow(prompt, options = {}) {
     return allButtons.find(b =>
       /send|submit|发送/i.test(b.getAttribute('aria-label') || b.getAttribute('data-testid') || '')
     ) || null;
+  }
+
+  function isTemporaryChatControlActive(control) {
+    return control.getAttribute('aria-pressed') === 'true' ||
+      control.getAttribute('aria-checked') === 'true' ||
+      control.getAttribute('data-state') === 'checked';
+  }
+
+  async function enableTemporaryChat() {
+    const labelPattern = /temporary chat|temporary|临时|臨時|暫時/i;
+    const controls = Array.from(document.querySelectorAll('button, [role="button"], a'));
+    const control = controls.find((candidate) => {
+      const label = [
+        candidate.getAttribute('aria-label') || '',
+        candidate.getAttribute('title') || '',
+        candidate.textContent || '',
+      ].join(' ');
+
+      return labelPattern.test(label);
+    });
+
+    if (!control || isTemporaryChatControlActive(control)) {
+      return false;
+    }
+
+    control.click();
+    await new Promise((resolve) => { setTimeout(resolve, 300); });
+    return true;
   }
 
   function showFallbackModal(text, reason) {
@@ -117,6 +146,13 @@ export async function runChatgptSendFlow(prompt, options = {}) {
   }
 
   let lastReason = 'unknown';
+  if (preferTemporaryChat) {
+    try {
+      await enableTemporaryChat();
+    } catch (err) {
+      console.warn('[ChatGPT Web Injector] Temporary Chat activation failed:', err);
+    }
+  }
 
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
     const input = findFirst(inputSelectors);

--- a/src/service_worker.js
+++ b/src/service_worker.js
@@ -5,6 +5,7 @@ import { renderTemplate } from './template.js';
 const MENU_ID = 'send-to-chatgpt';
 const MENU_ITEM_PREFIX = 'send-to-chatgpt-tpl-';
 const CHATGPT_URL = 'https://chatgpt.com/';
+const CHATGPT_TEMPORARY_URL = 'https://chatgpt.com/?temporary-chat=true';
 const TAB_WAIT_TIMEOUT_MS = 15000;
 
 let isMenuRebuildRunning = false;
@@ -45,14 +46,19 @@ async function sendWithTemplate(templateId, selectionText, tab) {
   await sendPromptToChatgpt(prompt);
 }
 
-async function sendPromptToChatgpt(prompt) {
-  const targetTab = await chrome.tabs.create({ url: CHATGPT_URL, active: true });
+async function sendPromptToChatgpt(prompt, options = {}) {
+  const targetUrl = options.preferTemporaryChat === true ? CHATGPT_TEMPORARY_URL : CHATGPT_URL;
+  const targetTab = await chrome.tabs.create({ url: targetUrl, active: true });
   await waitForTabComplete(targetTab.id, TAB_WAIT_TIMEOUT_MS);
 
   const [result] = await chrome.scripting.executeScript({
     target: { tabId: targetTab.id },
     func: runChatgptSendFlow,
-    args: [prompt, { maxAttempts: 24, intervalMs: 250 }],
+    args: [prompt, {
+      maxAttempts: 24,
+      intervalMs: 250,
+      preferTemporaryChat: options.preferTemporaryChat === true,
+    }],
   });
 
   console.log('[ChatGPT Web Injector] Runtime send result:', result?.result || result);
@@ -66,7 +72,7 @@ async function sendYoutubeSummary(payload) {
     transcript: payload?.transcript || '',
   });
 
-  await sendPromptToChatgpt(prompt);
+  await sendPromptToChatgpt(prompt, { preferTemporaryChat: true });
 }
 
 async function rebuildContextMenuOnce() {

--- a/src/youtube_summary.css
+++ b/src/youtube_summary.css
@@ -1,4 +1,5 @@
-#chatgpt-web-injector-youtube-summary {
+#chatgpt-web-injector-youtube-summary,
+#chatgpt-web-injector-youtube-transcript {
   min-width: 36px;
   height: 36px;
   margin: 0 2px;
@@ -16,8 +17,18 @@
   vertical-align: top;
 }
 
+#chatgpt-web-injector-youtube-transcript {
+  background: rgba(255, 255, 255, 0.92);
+  color: #0f172a;
+  font-size: 12px;
+}
+
 #chatgpt-web-injector-youtube-summary:hover {
   background: #10a37f;
+}
+
+#chatgpt-web-injector-youtube-transcript:hover {
+  background: #fff;
 }
 
 #chatgpt-web-injector-youtube-summary:disabled {

--- a/src/youtube_summary.js
+++ b/src/youtube_summary.js
@@ -269,13 +269,6 @@ async function openTranscriptPanel() {
     return;
   }
 
-  const visibleButton = findTranscriptButton();
-  if (visibleButton) {
-    visibleButton.click();
-    showStatus('Transcript open');
-    return;
-  }
-
   const transcriptButton = await waitForTranscriptButton();
   if (!transcriptButton) {
     showStatus('Transcript unavailable');

--- a/src/youtube_summary.js
+++ b/src/youtube_summary.js
@@ -1,5 +1,6 @@
 (function initYoutubeSummaryContentScript() {
 const YOUTUBE_SUMMARY_BUTTON_ID = 'chatgpt-web-injector-youtube-summary';
+const YOUTUBE_TRANSCRIPT_BUTTON_ID = 'chatgpt-web-injector-youtube-transcript';
 const YOUTUBE_SUMMARY_STATUS_ID = 'chatgpt-web-injector-youtube-status';
 const YOUTUBE_WATCH_PATH = '/watch';
 const BUTTON_RETRY_MS = 750;
@@ -28,6 +29,7 @@ function isWatchPage() {
 
 function removeButton() {
   document.getElementById(YOUTUBE_SUMMARY_BUTTON_ID)?.remove();
+  document.getElementById(YOUTUBE_TRANSCRIPT_BUTTON_ID)?.remove();
   document.getElementById(YOUTUBE_SUMMARY_STATUS_ID)?.remove();
 }
 
@@ -202,6 +204,13 @@ function findTranscriptButton() {
   const buttons = Array.from(document.querySelectorAll('button'));
 
   return buttons.find((button) => {
+    if (
+      button.id === YOUTUBE_SUMMARY_BUTTON_ID ||
+      button.id === YOUTUBE_TRANSCRIPT_BUTTON_ID
+    ) {
+      return false;
+    }
+
     const label = [
       button.getAttribute('aria-label') || '',
       button.textContent || '',
@@ -252,6 +261,29 @@ async function fetchTranscriptFromDom() {
   }
 
   return openedTranscript;
+}
+
+async function openTranscriptPanel() {
+  if (readTranscriptFromDom()) {
+    showStatus('Transcript open');
+    return;
+  }
+
+  const visibleButton = findTranscriptButton();
+  if (visibleButton) {
+    visibleButton.click();
+    showStatus('Transcript open');
+    return;
+  }
+
+  const transcriptButton = await waitForTranscriptButton();
+  if (!transcriptButton) {
+    showStatus('Transcript unavailable');
+    return;
+  }
+
+  transcriptButton.click();
+  showStatus('Transcript open');
 }
 
 async function fetchCurrentPlayerResponse() {
@@ -445,6 +477,24 @@ function createButton() {
   return button;
 }
 
+function createTranscriptButton() {
+  const button = document.createElement('button');
+  button.id = YOUTUBE_TRANSCRIPT_BUTTON_ID;
+  button.type = 'button';
+  button.title = 'Show YouTube transcript';
+  button.setAttribute('aria-label', 'Show YouTube transcript');
+  button.textContent = 'TR';
+  button.addEventListener('click', (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    openTranscriptPanel().catch((error) => {
+      console.warn('[ChatGPT Web Injector] YouTube transcript panel failed:', error);
+      showStatus('Transcript unavailable');
+    });
+  });
+  return button;
+}
+
 function mountButton() {
   clearTimeout(mountTimer);
 
@@ -453,7 +503,10 @@ function mountButton() {
     return;
   }
 
-  if (document.getElementById(YOUTUBE_SUMMARY_BUTTON_ID)) {
+  if (
+    document.getElementById(YOUTUBE_SUMMARY_BUTTON_ID) &&
+    document.getElementById(YOUTUBE_TRANSCRIPT_BUTTON_ID)
+  ) {
     return;
   }
 
@@ -463,7 +516,12 @@ function mountButton() {
     return;
   }
 
-  subtitlesButton.insertAdjacentElement('afterend', createButton());
+  document.getElementById(YOUTUBE_SUMMARY_BUTTON_ID)?.remove();
+  document.getElementById(YOUTUBE_TRANSCRIPT_BUTTON_ID)?.remove();
+
+  const summaryButton = createButton();
+  subtitlesButton.insertAdjacentElement('afterend', summaryButton);
+  summaryButton.insertAdjacentElement('afterend', createTranscriptButton());
 }
 
 function handleNavigation() {

--- a/tests/chatgpt_content.test.js
+++ b/tests/chatgpt_content.test.js
@@ -106,3 +106,43 @@ test('runChatgptSendFlow shows fallback modal when send control is missing', asy
   assert.equal(result.reason, 'send_not_found');
   assert.equal(Boolean(modal), true);
 });
+
+test('runChatgptSendFlow enables Temporary Chat before sending when requested', async () => {
+  const dom = new JSDOM(`
+    <html>
+      <body>
+        <button aria-label="Temporary chat">Temporary</button>
+        <textarea id="composer"></textarea>
+        <button data-testid="send-button">Send</button>
+      </body>
+    </html>
+  `);
+
+  const { document } = dom.window;
+  const temporary = document.querySelector('[aria-label="Temporary chat"]');
+  const send = document.querySelector('[data-testid="send-button"]');
+
+  let temporaryClicked = false;
+  let sendClicked = false;
+
+  temporary.addEventListener('click', () => {
+    temporaryClicked = true;
+  });
+
+  send.addEventListener('click', (event) => {
+    event.preventDefault();
+    sendClicked = true;
+  });
+
+  const result = await withDom(dom, () =>
+    runChatgptSendFlow('temporary hello', {
+      maxAttempts: 1,
+      intervalMs: 1,
+      preferTemporaryChat: true,
+    })
+  );
+
+  assert.equal(result.ok, true);
+  assert.equal(temporaryClicked, true);
+  assert.equal(sendClicked, true);
+});

--- a/tests/youtube_summary.test.js
+++ b/tests/youtube_summary.test.js
@@ -43,7 +43,7 @@ test('YouTube summary controls include a transcript panel button', () => {
   assert.equal(button.getAttribute('aria-label'), 'Show YouTube transcript');
 });
 
-test('YouTube transcript panel button clicks the native transcript control', () => {
+test('YouTube transcript panel button clicks the native transcript control', async () => {
   const dom = new JSDOM(`
     <html>
       <body>
@@ -67,6 +67,7 @@ test('YouTube transcript panel button clicks the native transcript control', () 
 
   const button = dom.window.document.getElementById('chatgpt-web-injector-youtube-transcript');
   button.click();
+  await Promise.resolve();
 
   assert.equal(nativeTranscriptClicked, true);
 });

--- a/tests/youtube_summary.test.js
+++ b/tests/youtube_summary.test.js
@@ -1,0 +1,72 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { JSDOM } from 'jsdom';
+
+function loadYoutubeSummary(dom) {
+  const previousChrome = globalThis.chrome;
+
+  globalThis.chrome = {
+    runtime: {
+      sendMessage() {},
+    },
+  };
+
+  const transcriptSource = readFileSync(new URL('../src/youtube_transcript.js', import.meta.url), 'utf8');
+  const summarySource = readFileSync(new URL('../src/youtube_summary.js', import.meta.url), 'utf8');
+
+  dom.window.eval(transcriptSource);
+  dom.window.eval(summarySource);
+
+  globalThis.chrome = previousChrome;
+}
+
+test('YouTube summary controls include a transcript panel button', () => {
+  const dom = new JSDOM(`
+    <html>
+      <body>
+        <div class="ytp-chrome-controls">
+          <button class="ytp-subtitles-button" aria-pressed="false">CC</button>
+        </div>
+      </body>
+    </html>
+  `, {
+    runScripts: 'outside-only',
+    url: 'https://www.youtube.com/watch?v=test123',
+  });
+
+  loadYoutubeSummary(dom);
+
+  const button = dom.window.document.getElementById('chatgpt-web-injector-youtube-transcript');
+
+  assert.ok(button);
+  assert.equal(button.getAttribute('aria-label'), 'Show YouTube transcript');
+});
+
+test('YouTube transcript panel button clicks the native transcript control', () => {
+  const dom = new JSDOM(`
+    <html>
+      <body>
+        <div class="ytp-chrome-controls">
+          <button class="ytp-subtitles-button" aria-pressed="false">CC</button>
+        </div>
+        <button aria-label="Show transcript">Show transcript</button>
+      </body>
+    </html>
+  `, {
+    runScripts: 'outside-only',
+    url: 'https://www.youtube.com/watch?v=test123',
+  });
+
+  let nativeTranscriptClicked = false;
+  dom.window.document.querySelector('[aria-label="Show transcript"]').addEventListener('click', () => {
+    nativeTranscriptClicked = true;
+  });
+
+  loadYoutubeSummary(dom);
+
+  const button = dom.window.document.getElementById('chatgpt-web-injector-youtube-transcript');
+  button.click();
+
+  assert.equal(nativeTranscriptClicked, true);
+});


### PR DESCRIPTION
## Summary
- Add a YouTube player transcript button that opens the native transcript panel when available.
- Send YouTube summaries through ChatGPT Temporary Chat by default while preserving regular selected-text sends.
- Add regression coverage for Temporary Chat activation and YouTube transcript button behavior.

## Files
- src/youtube_summary.js
- src/youtube_summary.css
- src/service_worker.js
- src/chatgpt_content.js
- tests/chatgpt_content.test.js
- tests/youtube_summary.test.js

## Verification
- npm test
- node --check src/chatgpt_content.js
- node --check src/service_worker.js
- node --check src/youtube_summary.js
- git diff --check

Closes #30