### PR TITLE
feat: configure YouTube Temporary Chat

### DIFF
--- a/options/options.css
+++ b/options/options.css
@@ -110,6 +110,18 @@ label:first-child {
   margin-top: 0;
 }
 
+.checkbox-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 14px;
+}
+
+.checkbox-row input {
+  width: 16px;
+  height: 16px;
+}
+
 input[type='text'] {
   width: 100%;
   padding: 8px 10px;

--- a/options/options.html
+++ b/options/options.html
@@ -50,6 +50,11 @@
           Available variables: <code>{{title}}</code>, <code>{{url}}</code>, <code>{{transcript}}</code>
         </p>
 
+        <label class="checkbox-row" for="youtube-temporary-chat">
+          <input id="youtube-temporary-chat" type="checkbox" />
+          <span>Use Temporary Chat for YouTube summaries</span>
+        </label>
+
         <div class="actions">
           <button id="save-youtube-tpl" type="button">Save YouTube template</button>
         </div>

--- a/options/options.js
+++ b/options/options.js
@@ -1,10 +1,12 @@
 import { DEFAULT_TEMPLATE } from '../src/template.js';
 import {
   loadTemplates,
+  loadYoutubeSummaryTemporaryChatEnabled,
   loadYoutubeSummaryTemplate,
   makeId,
   resetYoutubeSummaryTemplate,
   saveTemplates,
+  saveYoutubeSummaryTemporaryChatEnabled,
   saveYoutubeSummaryTemplate,
 } from '../src/storage.js';
 
@@ -16,6 +18,7 @@ const saveTplBtn = document.getElementById('save-tpl');
 const cancelTplBtn = document.getElementById('cancel-tpl');
 const addTplBtn = document.getElementById('add-template');
 const youtubeBodyInput = document.getElementById('youtube-tpl-body');
+const youtubeTemporaryChatInput = document.getElementById('youtube-temporary-chat');
 const saveYoutubeTplBtn = document.getElementById('save-youtube-tpl');
 const resetYoutubeTplBtn = document.getElementById('reset-youtube-tpl');
 const statusEl = document.getElementById('status');
@@ -198,9 +201,19 @@ resetYoutubeTplBtn.addEventListener('click', () => {
   });
 });
 
+youtubeTemporaryChatInput.addEventListener('change', () => {
+  saveYoutubeSummaryTemporaryChatEnabled(youtubeTemporaryChatInput.checked).then(() => {
+    setStatus('YouTube Summary chat mode saved.');
+  }).catch((err) => {
+    console.error('[ChatGPT Web Injector] YouTube Temporary Chat save failed:', err);
+    setStatus('Save failed. Please try again.');
+  });
+});
+
 async function init() {
   state = await loadTemplates();
   youtubeBodyInput.value = await loadYoutubeSummaryTemplate();
+  youtubeTemporaryChatInput.checked = await loadYoutubeSummaryTemporaryChatEnabled();
   renderList();
 
   if (window.location.hash === '#youtube-summary-template') {

--- a/src/chatgpt_content.js
+++ b/src/chatgpt_content.js
@@ -4,7 +4,7 @@ export async function runChatgptSendFlow(prompt, options = {}) {
   const preferTemporaryChat = options.preferTemporaryChat === true;
   const fallbackId = 'chatgpt-web-injector-fallback';
 
-  const inputSelectors = ['textarea', "[contenteditable='true']", "div[role='textbox']"];
+  const inputSelectors = ['textarea', '[contenteditable]', "div[role='textbox']"];
   const sendSelectors = [
     "button[data-testid='send-button']",
     "button[data-testid*='send']",
@@ -156,12 +156,9 @@ export async function runChatgptSendFlow(prompt, options = {}) {
 
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
     const input = findFirst(inputSelectors);
-    const sendButton = findSendButton();
 
     if (!input) {
       lastReason = 'input_not_found';
-    } else if (!sendButton) {
-      lastReason = 'send_not_found';
     } else {
       try {
         if (input.tagName === 'TEXTAREA' || input.tagName === 'INPUT') {
@@ -183,21 +180,24 @@ export async function runChatgptSendFlow(prompt, options = {}) {
       // Wait for React to process the injected text and enable the send button
       await new Promise((resolve) => { setTimeout(resolve, 300); });
 
-      // Re-query send button after wait — it may have become enabled
+      // Re-query send button after input — ChatGPT may only render it after text exists.
       const sendButtonReady = findSendButton();
 
       if (sendButtonReady && !sendButtonReady.disabled) {
         sendButtonReady.click();
-      } else {
-        // Fallback: dispatch Enter keydown on the input
+        return { ok: true, attempts: attempt };
+      } else if (sendButtonReady) {
+        // Fallback: dispatch Enter keydown on the input when the button exists but is not clickable yet.
         input.dispatchEvent(new KeyboardEvent('keydown', {
           key: 'Enter',
           code: 'Enter',
           bubbles: true,
           cancelable: true,
         }));
+        return { ok: true, attempts: attempt };
+      } else {
+        lastReason = 'send_not_found';
       }
-      return { ok: true, attempts: attempt };
     }
 
     if (attempt < maxAttempts) {

--- a/src/chatgpt_content.js
+++ b/src/chatgpt_content.js
@@ -103,6 +103,14 @@ export async function runChatgptSendFlow(prompt, options = {}) {
       control.getAttribute('data-state') === 'checked';
   }
 
+  function isTemporaryChatUrl() {
+    try {
+      return new window.URL(window.location.href).searchParams.get('temporary-chat') === 'true';
+    } catch (_error) {
+      return false;
+    }
+  }
+
   async function enableTemporaryChat() {
     const labelPattern = /temporary chat|temporary|临时|臨時|暫時/i;
     const controls = Array.from(document.querySelectorAll('button, [role="button"], a'));
@@ -207,7 +215,7 @@ export async function runChatgptSendFlow(prompt, options = {}) {
   }
 
   let lastReason = 'unknown';
-  if (preferTemporaryChat) {
+  if (preferTemporaryChat && !isTemporaryChatUrl()) {
     try {
       await enableTemporaryChat();
     } catch (err) {
@@ -238,14 +246,7 @@ export async function runChatgptSendFlow(prompt, options = {}) {
         sendButtonReady.click();
         return { ok: true, attempts: attempt };
       } else if (sendButtonReady) {
-        // Fallback: dispatch Enter keydown on the input when the button exists but is not clickable yet.
-        input.dispatchEvent(new KeyboardEvent('keydown', {
-          key: 'Enter',
-          code: 'Enter',
-          bubbles: true,
-          cancelable: true,
-        }));
-        return { ok: true, attempts: attempt };
+        lastReason = 'send_disabled';
       } else {
         lastReason = 'send_not_found';
       }

--- a/src/chatgpt_content.js
+++ b/src/chatgpt_content.js
@@ -31,9 +31,70 @@ export async function runChatgptSendFlow(prompt, options = {}) {
     if (btn) return btn;
     // Fall back: any button near the input that looks like a send button
     const allButtons = Array.from(document.querySelectorAll('button'));
-    return allButtons.find(b =>
-      /send|submit|发送/i.test(b.getAttribute('aria-label') || b.getAttribute('data-testid') || '')
+    return allButtons.find((button) =>
+      /send|submit|发送|提交/i.test(
+        button.getAttribute('aria-label') || button.getAttribute('data-testid') || ''
+      )
     ) || null;
+  }
+
+  function dispatchTextInputEvents(input, text) {
+    if (typeof InputEvent === 'function') {
+      input.dispatchEvent(new InputEvent('input', {
+        bubbles: true,
+        cancelable: true,
+        data: text,
+        inputType: 'insertText',
+      }));
+    } else {
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+  }
+
+  function setNativeValue(input, text) {
+    const descriptor = Object.getOwnPropertyDescriptor(input.constructor.prototype, 'value');
+    if (descriptor?.set) {
+      descriptor.set.call(input, text);
+    } else {
+      input.value = text;
+    }
+  }
+
+  function selectEditableContents(input) {
+    const selection = window.getSelection?.();
+    if (!selection || !document.createRange) {
+      return;
+    }
+
+    const range = document.createRange();
+    range.selectNodeContents(input);
+    selection.removeAllRanges();
+    selection.addRange(range);
+  }
+
+  function setContentEditableText(input, text) {
+    input.textContent = text;
+    dispatchTextInputEvents(input, text);
+  }
+
+  function insertPrompt(input, text) {
+    input.focus();
+
+    if (input.tagName === 'TEXTAREA' || input.tagName === 'INPUT') {
+      setNativeValue(input, text);
+      dispatchTextInputEvents(input, text);
+      return;
+    }
+
+    selectEditableContents(input);
+    const inserted = document.execCommand('insertText', false, text);
+    if (!inserted || !input.textContent?.includes(text)) {
+      setContentEditableText(input, text);
+    } else {
+      dispatchTextInputEvents(input, text);
+    }
   }
 
   function isTemporaryChatControlActive(control) {
@@ -161,17 +222,7 @@ export async function runChatgptSendFlow(prompt, options = {}) {
       lastReason = 'input_not_found';
     } else {
       try {
-        if (input.tagName === 'TEXTAREA' || input.tagName === 'INPUT') {
-          input.focus();
-          input.value = prompt;
-          input.dispatchEvent(new Event('input', { bubbles: true }));
-          input.dispatchEvent(new Event('change', { bubbles: true }));
-        } else {
-          // contenteditable div (ChatGPT's current input)
-          input.focus();
-          document.execCommand('selectAll', false, null);
-          document.execCommand('insertText', false, prompt);
-        }
+        insertPrompt(input, prompt);
       } catch (err) {
         lastReason = `inject_error: ${err.message}`;
         continue;

--- a/src/service_worker.js
+++ b/src/service_worker.js
@@ -12,6 +12,8 @@ const MENU_ITEM_PREFIX = 'send-to-chatgpt-tpl-';
 const CHATGPT_URL = 'https://chatgpt.com/';
 const CHATGPT_TEMPORARY_URL = 'https://chatgpt.com/?temporary-chat=true';
 const TAB_WAIT_TIMEOUT_MS = 15000;
+const INJECT_ATTEMPTS = 3;
+const INJECT_RETRY_MS = 750;
 
 let isMenuRebuildRunning = false;
 let hasPendingMenuRebuild = false;
@@ -61,6 +63,40 @@ export function waitForTabComplete(tabId, timeoutMs) {
   });
 }
 
+function isTransientFrameError(error) {
+  return /frame with id \d+ was removed/i.test(error?.message || '');
+}
+
+export async function executeChatgptSendFlow(tabId, prompt, options = {}) {
+  const injectAttempts = Number.isFinite(options.injectAttempts) ? options.injectAttempts : INJECT_ATTEMPTS;
+  const injectRetryMs = Number.isFinite(options.injectRetryMs) ? options.injectRetryMs : INJECT_RETRY_MS;
+
+  for (let attempt = 1; attempt <= injectAttempts; attempt += 1) {
+    try {
+      const [result] = await chrome.scripting.executeScript({
+        target: { tabId },
+        func: runChatgptSendFlow,
+        args: [prompt, {
+          maxAttempts: options.maxAttempts,
+          intervalMs: options.intervalMs,
+          preferTemporaryChat: options.preferTemporaryChat === true,
+        }],
+      });
+
+      return result?.result || result;
+    } catch (error) {
+      if (!isTransientFrameError(error) || attempt === injectAttempts) {
+        throw error;
+      }
+
+      await waitForTabComplete(tabId, TAB_WAIT_TIMEOUT_MS);
+      await new Promise((resolve) => { setTimeout(resolve, injectRetryMs); });
+    }
+  }
+
+  throw new Error('chatgpt_injection_failed');
+}
+
 async function sendWithTemplate(templateId, selectionText, tab) {
   const payload = {
     selection: selectionText || '',
@@ -78,17 +114,13 @@ async function sendPromptToChatgpt(prompt, options = {}) {
   const targetTab = await chrome.tabs.create({ url: targetUrl, active: true });
   await waitForTabComplete(targetTab.id, TAB_WAIT_TIMEOUT_MS);
 
-  const [result] = await chrome.scripting.executeScript({
-    target: { tabId: targetTab.id },
-    func: runChatgptSendFlow,
-    args: [prompt, {
-      maxAttempts: 24,
-      intervalMs: 250,
-      preferTemporaryChat: options.preferTemporaryChat === true,
-    }],
+  const result = await executeChatgptSendFlow(targetTab.id, prompt, {
+    maxAttempts: 24,
+    intervalMs: 250,
+    preferTemporaryChat: options.preferTemporaryChat === true,
   });
 
-  console.log('[ChatGPT Web Injector] Runtime send result:', result?.result || result);
+  console.log('[ChatGPT Web Injector] Runtime send result:', result);
 }
 
 async function sendYoutubeSummary(payload) {

--- a/src/service_worker.js
+++ b/src/service_worker.js
@@ -1,5 +1,10 @@
 import { runChatgptSendFlow } from './chatgpt_content.js';
-import { loadTemplates, loadTemplateById, loadYoutubeSummaryTemplate } from './storage.js';
+import {
+  loadTemplates,
+  loadTemplateById,
+  loadYoutubeSummaryTemporaryChatEnabled,
+  loadYoutubeSummaryTemplate,
+} from './storage.js';
 import { renderTemplate } from './template.js';
 
 const MENU_ID = 'send-to-chatgpt';
@@ -10,6 +15,10 @@ const TAB_WAIT_TIMEOUT_MS = 15000;
 
 let isMenuRebuildRunning = false;
 let hasPendingMenuRebuild = false;
+
+export function getChatgptTargetUrl(preferTemporaryChat) {
+  return preferTemporaryChat ? CHATGPT_TEMPORARY_URL : CHATGPT_URL;
+}
 
 function waitForTabComplete(tabId, timeoutMs) {
   return new Promise((resolve, reject) => {
@@ -47,7 +56,7 @@ async function sendWithTemplate(templateId, selectionText, tab) {
 }
 
 async function sendPromptToChatgpt(prompt, options = {}) {
-  const targetUrl = options.preferTemporaryChat === true ? CHATGPT_TEMPORARY_URL : CHATGPT_URL;
+  const targetUrl = getChatgptTargetUrl(options.preferTemporaryChat === true);
   const targetTab = await chrome.tabs.create({ url: targetUrl, active: true });
   await waitForTabComplete(targetTab.id, TAB_WAIT_TIMEOUT_MS);
 
@@ -65,6 +74,7 @@ async function sendPromptToChatgpt(prompt, options = {}) {
 }
 
 async function sendYoutubeSummary(payload) {
+  const preferTemporaryChat = await loadYoutubeSummaryTemporaryChatEnabled();
   const template = await loadYoutubeSummaryTemplate();
   const prompt = renderTemplate(template, {
     title: payload?.title || '',
@@ -72,7 +82,7 @@ async function sendYoutubeSummary(payload) {
     transcript: payload?.transcript || '',
   });
 
-  await sendPromptToChatgpt(prompt, { preferTemporaryChat: true });
+  await sendPromptToChatgpt(prompt, { preferTemporaryChat });
 }
 
 async function rebuildContextMenuOnce() {

--- a/src/service_worker.js
+++ b/src/service_worker.js
@@ -20,9 +20,24 @@ export function getChatgptTargetUrl(preferTemporaryChat) {
   return preferTemporaryChat ? CHATGPT_TEMPORARY_URL : CHATGPT_URL;
 }
 
-function waitForTabComplete(tabId, timeoutMs) {
+export function waitForTabComplete(tabId, timeoutMs) {
   return new Promise((resolve, reject) => {
+    let settled = false;
+    const finish = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeoutId);
+      chrome.tabs.onUpdated.removeListener(onUpdated);
+      resolve();
+    };
+
     const timeoutId = setTimeout(() => {
+      if (settled) {
+        return;
+      }
+      settled = true;
       chrome.tabs.onUpdated.removeListener(onUpdated);
       reject(new Error('tab_load_timeout'));
     }, timeoutMs);
@@ -33,13 +48,16 @@ function waitForTabComplete(tabId, timeoutMs) {
       }
 
       if (changeInfo.status === 'complete') {
-        clearTimeout(timeoutId);
-        chrome.tabs.onUpdated.removeListener(onUpdated);
-        resolve();
+        finish();
       }
     };
 
     chrome.tabs.onUpdated.addListener(onUpdated);
+    chrome.tabs.get(tabId).then((tab) => {
+      if (tab?.status === 'complete') {
+        finish();
+      }
+    }).catch(() => {});
   });
 }
 

--- a/src/storage.js
+++ b/src/storage.js
@@ -4,6 +4,7 @@ const LEGACY_KEY = 'defaultTemplate';
 const TEMPLATES_KEY = 'templates';
 const ACTIVE_ID_KEY = 'activeTemplateId';
 const YOUTUBE_SUMMARY_TEMPLATE_KEY = 'youtubeSummaryTemplate';
+const YOUTUBE_SUMMARY_TEMPORARY_CHAT_KEY = 'youtubeSummaryTemporaryChatEnabled';
 
 export const DEFAULT_YOUTUBE_SUMMARY_TEMPLATE = `You are a precise video summary assistant.
 
@@ -118,4 +119,13 @@ export async function saveYoutubeSummaryTemplate(body) {
 export async function resetYoutubeSummaryTemplate() {
   await saveYoutubeSummaryTemplate(DEFAULT_YOUTUBE_SUMMARY_TEMPLATE);
   return DEFAULT_YOUTUBE_SUMMARY_TEMPLATE;
+}
+
+export async function loadYoutubeSummaryTemporaryChatEnabled() {
+  const data = await chrome.storage.sync.get([YOUTUBE_SUMMARY_TEMPORARY_CHAT_KEY]);
+  return data[YOUTUBE_SUMMARY_TEMPORARY_CHAT_KEY] !== false;
+}
+
+export async function saveYoutubeSummaryTemporaryChatEnabled(enabled) {
+  await chrome.storage.sync.set({ [YOUTUBE_SUMMARY_TEMPORARY_CHAT_KEY]: enabled === true });
 }

--- a/tests/chatgpt_content.test.js
+++ b/tests/chatgpt_content.test.js
@@ -8,11 +8,15 @@ function withDom(dom, callback) {
   const previousWindow = globalThis.window;
   const previousDocument = globalThis.document;
   const previousEvent = globalThis.Event;
+  const previousInputEvent = globalThis.InputEvent;
+  const previousKeyboardEvent = globalThis.KeyboardEvent;
   const previousMouseEvent = globalThis.MouseEvent;
 
   globalThis.window = dom.window;
   globalThis.document = dom.window.document;
   globalThis.Event = dom.window.Event;
+  globalThis.InputEvent = dom.window.InputEvent;
+  globalThis.KeyboardEvent = dom.window.KeyboardEvent;
   globalThis.MouseEvent = dom.window.MouseEvent;
 
   return Promise.resolve()
@@ -21,6 +25,8 @@ function withDom(dom, callback) {
       globalThis.window = previousWindow;
       globalThis.document = previousDocument;
       globalThis.Event = previousEvent;
+      globalThis.InputEvent = previousInputEvent;
+      globalThis.KeyboardEvent = previousKeyboardEvent;
       globalThis.MouseEvent = previousMouseEvent;
     });
 }
@@ -144,6 +150,46 @@ test('runChatgptSendFlow enables Temporary Chat before sending when requested', 
 
   assert.equal(result.ok, true);
   assert.equal(temporaryClicked, true);
+  assert.equal(sendClicked, true);
+});
+
+test('runChatgptSendFlow does not toggle Temporary Chat when already on a temporary chat URL', async () => {
+  const dom = new JSDOM(`
+    <html>
+      <body>
+        <button aria-label="Temporary chat">Temporary</button>
+        <textarea id="composer"></textarea>
+        <button data-testid="send-button">Send</button>
+      </body>
+    </html>
+  `, { url: 'https://chatgpt.com/?temporary-chat=true' });
+
+  const { document } = dom.window;
+  const temporary = document.querySelector('[aria-label="Temporary chat"]');
+  const send = document.querySelector('[data-testid="send-button"]');
+
+  let temporaryClicked = false;
+  let sendClicked = false;
+
+  temporary.addEventListener('click', () => {
+    temporaryClicked = true;
+  });
+
+  send.addEventListener('click', (event) => {
+    event.preventDefault();
+    sendClicked = true;
+  });
+
+  const result = await withDom(dom, () =>
+    runChatgptSendFlow('temporary url hello', {
+      maxAttempts: 1,
+      intervalMs: 1,
+      preferTemporaryChat: true,
+    })
+  );
+
+  assert.equal(result.ok, true);
+  assert.equal(temporaryClicked, false);
   assert.equal(sendClicked, true);
 });
 
@@ -282,5 +328,40 @@ test('runChatgptSendFlow recognizes Submit message as the send button', async ()
 
   assert.equal(result.ok, true);
   assert.equal(textarea.value, 'submit hello');
+  assert.equal(clicked, true);
+});
+
+test('runChatgptSendFlow waits for the send button to become enabled before returning', async () => {
+  const dom = new JSDOM(`
+    <html>
+      <body>
+        <textarea id="composer"></textarea>
+        <button aria-label="Submit message" disabled>Submit</button>
+      </body>
+    </html>
+  `);
+
+  const { document } = dom.window;
+  const textarea = document.querySelector('#composer');
+  const submit = document.querySelector('[aria-label="Submit message"]');
+
+  let clicked = false;
+  textarea.addEventListener('input', () => {
+    setTimeout(() => {
+      submit.disabled = false;
+    }, 450);
+  });
+
+  submit.addEventListener('click', (event) => {
+    event.preventDefault();
+    clicked = true;
+  });
+
+  const result = await withDom(dom, () =>
+    runChatgptSendFlow('wait for enabled', { maxAttempts: 5, intervalMs: 50 })
+  );
+
+  assert.equal(result.ok, true);
+  assert.equal(textarea.value, 'wait for enabled');
   assert.equal(clicked, true);
 });

--- a/tests/chatgpt_content.test.js
+++ b/tests/chatgpt_content.test.js
@@ -182,6 +182,44 @@ test('runChatgptSendFlow inserts prompt into plaintext-only contenteditable comp
   assert.equal(clicked, true);
 });
 
+test('runChatgptSendFlow falls back when execCommand does not update contenteditable composer', async () => {
+  const dom = new JSDOM(`
+    <html>
+      <body>
+        <div id="composer" contenteditable="true" role="textbox"></div>
+      </body>
+    </html>
+  `);
+
+  const { document } = dom.window;
+  const composer = document.querySelector('#composer');
+
+  document.execCommand = () => false;
+
+  let clicked = false;
+  composer.addEventListener('input', () => {
+    if (document.querySelector('[aria-label="Submit message"]')) {
+      return;
+    }
+
+    const send = document.createElement('button');
+    send.setAttribute('aria-label', 'Submit message');
+    send.addEventListener('click', (event) => {
+      event.preventDefault();
+      clicked = true;
+    });
+    document.body.append(send);
+  });
+
+  const result = await withDom(dom, () =>
+    runChatgptSendFlow('fallback contenteditable hello', { maxAttempts: 1, intervalMs: 1 })
+  );
+
+  assert.equal(result.ok, true);
+  assert.equal(composer.textContent, 'fallback contenteditable hello');
+  assert.equal(clicked, true);
+});
+
 test('runChatgptSendFlow injects prompt before the send button appears', async () => {
   const dom = new JSDOM(`
     <html>
@@ -215,5 +253,34 @@ test('runChatgptSendFlow injects prompt before the send button appears', async (
 
   assert.equal(result.ok, true);
   assert.equal(textarea.value, 'late send button');
+  assert.equal(clicked, true);
+});
+
+test('runChatgptSendFlow recognizes Submit message as the send button', async () => {
+  const dom = new JSDOM(`
+    <html>
+      <body>
+        <textarea id="composer"></textarea>
+        <button aria-label="Submit message">Submit</button>
+      </body>
+    </html>
+  `);
+
+  const { document } = dom.window;
+  const textarea = document.querySelector('#composer');
+  const submit = document.querySelector('[aria-label="Submit message"]');
+
+  let clicked = false;
+  submit.addEventListener('click', (event) => {
+    event.preventDefault();
+    clicked = true;
+  });
+
+  const result = await withDom(dom, () =>
+    runChatgptSendFlow('submit hello', { maxAttempts: 1, intervalMs: 1 })
+  );
+
+  assert.equal(result.ok, true);
+  assert.equal(textarea.value, 'submit hello');
   assert.equal(clicked, true);
 });

--- a/tests/chatgpt_content.test.js
+++ b/tests/chatgpt_content.test.js
@@ -146,3 +146,74 @@ test('runChatgptSendFlow enables Temporary Chat before sending when requested', 
   assert.equal(temporaryClicked, true);
   assert.equal(sendClicked, true);
 });
+
+test('runChatgptSendFlow inserts prompt into plaintext-only contenteditable composer', async () => {
+  const dom = new JSDOM(`
+    <html>
+      <body>
+        <div id="composer" contenteditable="plaintext-only" role="textbox"></div>
+        <button data-testid="send-button">Send</button>
+      </body>
+    </html>
+  `);
+
+  const { document } = dom.window;
+  const composer = document.querySelector('#composer');
+  const send = document.querySelector('[data-testid="send-button"]');
+
+  document.execCommand = (_command, _showUi, value) => {
+    composer.textContent = value;
+    composer.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
+    return true;
+  };
+
+  let clicked = false;
+  send.addEventListener('click', (event) => {
+    event.preventDefault();
+    clicked = true;
+  });
+
+  const result = await withDom(dom, () =>
+    runChatgptSendFlow('plaintext hello', { maxAttempts: 1, intervalMs: 1 })
+  );
+
+  assert.equal(result.ok, true);
+  assert.equal(composer.textContent, 'plaintext hello');
+  assert.equal(clicked, true);
+});
+
+test('runChatgptSendFlow injects prompt before the send button appears', async () => {
+  const dom = new JSDOM(`
+    <html>
+      <body>
+        <textarea id="composer"></textarea>
+      </body>
+    </html>
+  `);
+
+  const { document } = dom.window;
+  const textarea = document.querySelector('#composer');
+
+  let clicked = false;
+  textarea.addEventListener('input', () => {
+    if (document.querySelector('[data-testid="send-button"]')) {
+      return;
+    }
+
+    const send = document.createElement('button');
+    send.setAttribute('data-testid', 'send-button');
+    send.addEventListener('click', (event) => {
+      event.preventDefault();
+      clicked = true;
+    });
+    document.body.append(send);
+  });
+
+  const result = await withDom(dom, () =>
+    runChatgptSendFlow('late send button', { maxAttempts: 1, intervalMs: 1 })
+  );
+
+  assert.equal(result.ok, true);
+  assert.equal(textarea.value, 'late send button');
+  assert.equal(clicked, true);
+});

--- a/tests/options_html.test.js
+++ b/tests/options_html.test.js
@@ -1,0 +1,14 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { JSDOM } from 'jsdom';
+
+test('Options page exposes a YouTube Temporary Chat toggle', () => {
+  const html = readFileSync(new URL('../options/options.html', import.meta.url), 'utf8');
+  const dom = new JSDOM(html);
+  const checkbox = dom.window.document.getElementById('youtube-temporary-chat');
+
+  assert.ok(checkbox);
+  assert.equal(checkbox.tagName, 'INPUT');
+  assert.equal(checkbox.getAttribute('type'), 'checkbox');
+});

--- a/tests/service_worker.test.js
+++ b/tests/service_worker.test.js
@@ -19,6 +19,9 @@ globalThis.chrome = {
     onChanged: { addListener() {} },
   },
   tabs: {
+    async create() {
+      return { id: 123, status: 'complete' };
+    },
     async get(tabId) {
       return { id: tabId, status: 'complete' };
     },
@@ -27,9 +30,18 @@ globalThis.chrome = {
       removeListener() {},
     },
   },
+  scripting: {
+    async executeScript() {
+      return [{ result: { ok: true } }];
+    },
+  },
 };
 
-const { getChatgptTargetUrl, waitForTabComplete } = await import('../src/service_worker.js');
+const {
+  executeChatgptSendFlow,
+  getChatgptTargetUrl,
+  waitForTabComplete,
+} = await import('../src/service_worker.js');
 
 after(() => {
   globalThis.chrome = previousChrome;
@@ -42,4 +54,25 @@ test('getChatgptTargetUrl returns temporary URL only when enabled', () => {
 
 test('waitForTabComplete resolves when the tab is already complete', async () => {
   await waitForTabComplete(123, 1);
+});
+
+test('executeChatgptSendFlow retries when ChatGPT replaces the main frame', async () => {
+  let attempts = 0;
+  globalThis.chrome.scripting.executeScript = async () => {
+    attempts += 1;
+    if (attempts === 1) {
+      throw new Error('Frame with ID 0 was removed.');
+    }
+    return [{ result: { ok: true } }];
+  };
+
+  const result = await executeChatgptSendFlow(123, 'hello', {
+    maxAttempts: 1,
+    intervalMs: 1,
+    injectAttempts: 2,
+    injectRetryMs: 1,
+  });
+
+  assert.equal(attempts, 2);
+  assert.deepEqual(result, { ok: true });
 });

--- a/tests/service_worker.test.js
+++ b/tests/service_worker.test.js
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const previousChrome = globalThis.chrome;
+
+globalThis.chrome = {
+  contextMenus: {
+    onClicked: { addListener() {} },
+    create() {},
+    removeAll(callback) {
+      callback();
+    },
+  },
+  runtime: {
+    onInstalled: { addListener() {} },
+    onMessage: { addListener() {} },
+  },
+  storage: {
+    onChanged: { addListener() {} },
+  },
+  tabs: {
+    onUpdated: {
+      addListener() {},
+      removeListener() {},
+    },
+  },
+};
+
+const { getChatgptTargetUrl } = await import('../src/service_worker.js');
+
+globalThis.chrome = previousChrome;
+
+test('getChatgptTargetUrl returns temporary URL only when enabled', () => {
+  assert.equal(getChatgptTargetUrl(true), 'https://chatgpt.com/?temporary-chat=true');
+  assert.equal(getChatgptTargetUrl(false), 'https://chatgpt.com/');
+});

--- a/tests/service_worker.test.js
+++ b/tests/service_worker.test.js
@@ -1,4 +1,4 @@
-import test from 'node:test';
+import test, { after } from 'node:test';
 import assert from 'node:assert/strict';
 
 const previousChrome = globalThis.chrome;
@@ -19,6 +19,9 @@ globalThis.chrome = {
     onChanged: { addListener() {} },
   },
   tabs: {
+    async get(tabId) {
+      return { id: tabId, status: 'complete' };
+    },
     onUpdated: {
       addListener() {},
       removeListener() {},
@@ -26,11 +29,17 @@ globalThis.chrome = {
   },
 };
 
-const { getChatgptTargetUrl } = await import('../src/service_worker.js');
+const { getChatgptTargetUrl, waitForTabComplete } = await import('../src/service_worker.js');
 
-globalThis.chrome = previousChrome;
+after(() => {
+  globalThis.chrome = previousChrome;
+});
 
 test('getChatgptTargetUrl returns temporary URL only when enabled', () => {
   assert.equal(getChatgptTargetUrl(true), 'https://chatgpt.com/?temporary-chat=true');
   assert.equal(getChatgptTargetUrl(false), 'https://chatgpt.com/');
+});
+
+test('waitForTabComplete resolves when the tab is already complete', async () => {
+  await waitForTabComplete(123, 1);
 });

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -3,8 +3,10 @@ import assert from 'node:assert/strict';
 
 import {
   DEFAULT_YOUTUBE_SUMMARY_TEMPLATE,
+  loadYoutubeSummaryTemporaryChatEnabled,
   loadYoutubeSummaryTemplate,
   resetYoutubeSummaryTemplate,
+  saveYoutubeSummaryTemporaryChatEnabled,
   saveYoutubeSummaryTemplate,
 } from '../src/storage.js';
 
@@ -85,6 +87,34 @@ test('resetYoutubeSummaryTemplate restores the default YouTube template', async 
 
     assert.equal(template, DEFAULT_YOUTUBE_SUMMARY_TEMPLATE);
     assert.equal(chromeStorage.store.youtubeSummaryTemplate, DEFAULT_YOUTUBE_SUMMARY_TEMPLATE);
+  } finally {
+    chromeStorage.restore();
+  }
+});
+
+test('loadYoutubeSummaryTemporaryChatEnabled defaults to true when unset', async () => {
+  const chromeStorage = installChromeStorage();
+
+  try {
+    const enabled = await loadYoutubeSummaryTemporaryChatEnabled();
+
+    assert.equal(enabled, true);
+  } finally {
+    chromeStorage.restore();
+  }
+});
+
+test('saveYoutubeSummaryTemporaryChatEnabled persists false and true values', async () => {
+  const chromeStorage = installChromeStorage();
+
+  try {
+    await saveYoutubeSummaryTemporaryChatEnabled(false);
+    assert.equal(await loadYoutubeSummaryTemporaryChatEnabled(), false);
+    assert.equal(chromeStorage.store.youtubeSummaryTemporaryChatEnabled, false);
+
+    await saveYoutubeSummaryTemporaryChatEnabled(true);
+    assert.equal(await loadYoutubeSummaryTemporaryChatEnabled(), true);
+    assert.equal(chromeStorage.store.youtubeSummaryTemporaryChatEnabled, true);
   } finally {
     chromeStorage.restore();
   }


### PR DESCRIPTION
## Summary
- Add a persisted YouTube Summary Temporary Chat setting that defaults to enabled.
- Add an Options page checkbox near the YouTube Summary template to toggle the behavior.
- Use the setting when opening ChatGPT for YouTube summaries while keeping normal selected-text sends on regular ChatGPT.

## Files
- src/storage.js
- src/service_worker.js
- options/options.html
- options/options.js
- options/options.css
- tests/storage.test.js
- tests/service_worker.test.js
- tests/options_html.test.js

## Verification
- npm test
- node --check src/storage.js
- node --check src/service_worker.js
- node --check options/options.js
- git diff --check

Closes #32