### PR TITLE
fix: toggle YouTube transcript panel

### DIFF
--- a/src/youtube_summary.js
+++ b/src/youtube_summary.js
@@ -162,7 +162,7 @@ function normalizeTimestamp(timestamp) {
 }
 
 function isElementVisible(element) {
-  if (!element) {
+  if (!element || !element.isConnected) {
     return false;
   }
 
@@ -269,7 +269,8 @@ function findTranscriptButton() {
   return buttons.find((button) => {
     if (
       button.id === YOUTUBE_SUMMARY_BUTTON_ID ||
-      button.id === YOUTUBE_TRANSCRIPT_BUTTON_ID
+      button.id === YOUTUBE_TRANSCRIPT_BUTTON_ID ||
+      !isElementVisible(button)
     ) {
       return false;
     }
@@ -282,8 +283,7 @@ function findTranscriptButton() {
   }) || null;
 }
 
-function findTranscriptCloseButton() {
-  const panel = findTranscriptPanel();
+function findTranscriptCloseButton(panel = findTranscriptPanel()) {
   if (!panel) {
     return null;
   }
@@ -359,8 +359,9 @@ async function fetchTranscriptFromDom() {
 }
 
 async function toggleTranscriptPanel() {
-  if (findVisibleTranscriptSegment()) {
-    const closeButton = findTranscriptCloseButton();
+  const panel = findTranscriptPanel();
+  if (panel) {
+    const closeButton = findTranscriptCloseButton(panel);
     if (!closeButton) {
       showStatus('Transcript unavailable');
       return;

--- a/src/youtube_summary.js
+++ b/src/youtube_summary.js
@@ -161,11 +161,48 @@ function normalizeTimestamp(timestamp) {
   return '00:00';
 }
 
+function isElementVisible(element) {
+  if (!element) {
+    return false;
+  }
+
+  let current = element;
+  while (current && current.nodeType === Node.ELEMENT_NODE) {
+    if (
+      current.hidden ||
+      current.getAttribute('aria-hidden') === 'true'
+    ) {
+      return false;
+    }
+
+    const youtubeVisibility = current.getAttribute('visibility') || '';
+    if (
+      youtubeVisibility.includes('HIDDEN') ||
+      youtubeVisibility.includes('COLLAPSED')
+    ) {
+      return false;
+    }
+
+    const style = window.getComputedStyle(current);
+    if (style.display === 'none' || style.visibility === 'hidden') {
+      return false;
+    }
+
+    current = current.parentElement;
+  }
+
+  return true;
+}
+
 function readTranscriptFromDom() {
   const segmentNodes = Array.from(document.querySelectorAll('ytd-transcript-segment-renderer'));
   const lines = [];
 
   for (const segment of segmentNodes) {
+    if (!isElementVisible(segment)) {
+      continue;
+    }
+
     const timestamp = segment.querySelector('.segment-timestamp')?.textContent?.trim() || '';
     const text = segment.querySelector('.segment-text')?.textContent?.trim() || '';
 
@@ -178,6 +215,10 @@ function readTranscriptFromDom() {
   const transcriptHelpers = window.ChatgptWebInjectorYoutubeTranscript;
 
   for (const segment of modernSegmentNodes) {
+    if (!isElementVisible(segment)) {
+      continue;
+    }
+
     const timestamp = segment.querySelector('.ytwTranscriptSegmentViewModelTimestamp')?.textContent?.trim() || '';
     const text = Array.from(segment.querySelectorAll('span.ytAttributedStringHost'))
       .map((node) => node.textContent?.trim() || '')
@@ -199,6 +240,28 @@ function readTranscriptFromDom() {
   return lines.join('\n');
 }
 
+function findVisibleTranscriptSegment() {
+  const selectors = [
+    'ytd-transcript-segment-renderer',
+    'transcript-segment-view-model',
+  ].join(', ');
+  return Array.from(document.querySelectorAll(selectors))
+    .find((segment) => isElementVisible(segment)) || null;
+}
+
+function findTranscriptPanel() {
+  const segment = findVisibleTranscriptSegment();
+  if (!segment) {
+    return null;
+  }
+
+  return segment.closest([
+    'ytd-engagement-panel-section-list-renderer',
+    'ytd-transcript-renderer',
+    'ytd-transcript-search-panel-renderer',
+  ].join(', ')) || segment.parentElement;
+}
+
 function findTranscriptButton() {
   const labelPattern = /show transcript|transcript|文字稿|转录|轉錄|逐字稿|转写文稿|內容轉文字|内容转文字/i;
   const buttons = Array.from(document.querySelectorAll('button'));
@@ -216,6 +279,38 @@ function findTranscriptButton() {
       button.textContent || '',
     ].join(' ');
     return labelPattern.test(label);
+  }) || null;
+}
+
+function findTranscriptCloseButton() {
+  const panel = findTranscriptPanel();
+  if (!panel) {
+    return null;
+  }
+
+  const closePattern = /close|dismiss|关闭|關閉/i;
+  const buttons = Array.from(panel.querySelectorAll([
+    'button',
+    '[role="button"]',
+    'yt-icon-button',
+    'tp-yt-paper-icon-button',
+  ].join(', ')));
+
+  return buttons.find((button) => {
+    if (
+      button.id === YOUTUBE_SUMMARY_BUTTON_ID ||
+      button.id === YOUTUBE_TRANSCRIPT_BUTTON_ID ||
+      !isElementVisible(button)
+    ) {
+      return false;
+    }
+
+    const label = [
+      button.getAttribute('aria-label') || '',
+      button.getAttribute('title') || '',
+      button.textContent || '',
+    ].join(' ');
+    return closePattern.test(label);
   }) || null;
 }
 
@@ -263,9 +358,15 @@ async function fetchTranscriptFromDom() {
   return openedTranscript;
 }
 
-async function openTranscriptPanel() {
-  if (readTranscriptFromDom()) {
-    showStatus('Transcript open');
+async function toggleTranscriptPanel() {
+  if (findVisibleTranscriptSegment()) {
+    const closeButton = findTranscriptCloseButton();
+    if (!closeButton) {
+      showStatus('Transcript unavailable');
+      return;
+    }
+
+    closeButton.click();
     return;
   }
 
@@ -276,7 +377,6 @@ async function openTranscriptPanel() {
   }
 
   transcriptButton.click();
-  showStatus('Transcript open');
 }
 
 async function fetchCurrentPlayerResponse() {
@@ -480,7 +580,7 @@ function createTranscriptButton() {
   button.addEventListener('click', (event) => {
     event.preventDefault();
     event.stopPropagation();
-    openTranscriptPanel().catch((error) => {
+    toggleTranscriptPanel().catch((error) => {
       console.warn('[ChatGPT Web Injector] YouTube transcript panel failed:', error);
       showStatus('Transcript unavailable');
     });

--- a/tests/youtube_summary.test.js
+++ b/tests/youtube_summary.test.js
@@ -91,6 +91,7 @@ test('YouTube transcript panel button opens when stale transcript DOM is hidden'
             <span class="segment-timestamp">0:01</span>
             <span class="segment-text">Stale closed transcript</span>
           </ytd-transcript-segment-renderer>
+          <button aria-label="Show transcript">Hidden show transcript</button>
         </ytd-engagement-panel-section-list-renderer>
         <button aria-label="Show transcript">Show transcript</button>
       </body>
@@ -101,7 +102,11 @@ test('YouTube transcript panel button opens when stale transcript DOM is hidden'
   });
 
   let nativeTranscriptClicked = false;
-  dom.window.document.querySelector('[aria-label="Show transcript"]').addEventListener('click', () => {
+  let hiddenTranscriptClicked = false;
+  dom.window.document.querySelector('ytd-engagement-panel-section-list-renderer button').addEventListener('click', () => {
+    hiddenTranscriptClicked = true;
+  });
+  dom.window.document.body.lastElementChild.addEventListener('click', () => {
     nativeTranscriptClicked = true;
   });
 
@@ -112,6 +117,7 @@ test('YouTube transcript panel button opens when stale transcript DOM is hidden'
   await Promise.resolve();
 
   assert.equal(nativeTranscriptClicked, true);
+  assert.equal(hiddenTranscriptClicked, false);
   assert.equal(dom.window.document.getElementById('chatgpt-web-injector-youtube-status'), null);
 });
 
@@ -149,6 +155,54 @@ test('YouTube transcript panel button closes an open transcript panel', async ()
   await Promise.resolve();
 
   assert.equal(closeClicked, true);
+  assert.equal(dom.window.document.getElementById('chatgpt-web-injector-youtube-status'), null);
+});
+
+test('YouTube transcript panel button reopens after closing the transcript panel', async () => {
+  const dom = new JSDOM(`
+    <html>
+      <body>
+        <div class="ytp-chrome-controls">
+          <button class="ytp-subtitles-button" aria-pressed="false">CC</button>
+        </div>
+        <ytd-engagement-panel-section-list-renderer>
+          <button aria-label="Close transcript">Close</button>
+          <ytd-transcript-segment-renderer>
+            <span class="segment-timestamp">0:01</span>
+            <span class="segment-text">Open transcript</span>
+          </ytd-transcript-segment-renderer>
+        </ytd-engagement-panel-section-list-renderer>
+        <button aria-label="Show transcript">Show transcript</button>
+      </body>
+    </html>
+  `, {
+    runScripts: 'outside-only',
+    url: 'https://www.youtube.com/watch?v=test123',
+  });
+
+  const panel = dom.window.document.querySelector('ytd-engagement-panel-section-list-renderer');
+  let closeClicked = false;
+  let showClicked = false;
+
+  dom.window.document.querySelector('[aria-label="Close transcript"]').addEventListener('click', () => {
+    closeClicked = true;
+    panel.setAttribute('visibility', 'ENGAGEMENT_PANEL_VISIBILITY_HIDDEN');
+  });
+  dom.window.document.body.lastElementChild.addEventListener('click', () => {
+    showClicked = true;
+    panel.setAttribute('visibility', 'ENGAGEMENT_PANEL_VISIBILITY_EXPANDED');
+  });
+
+  loadYoutubeSummary(dom);
+
+  const button = dom.window.document.getElementById('chatgpt-web-injector-youtube-transcript');
+  button.click();
+  await Promise.resolve();
+  button.click();
+  await Promise.resolve();
+
+  assert.equal(closeClicked, true);
+  assert.equal(showClicked, true);
   assert.equal(dom.window.document.getElementById('chatgpt-web-injector-youtube-status'), null);
 });
 

--- a/tests/youtube_summary.test.js
+++ b/tests/youtube_summary.test.js
@@ -76,6 +76,80 @@ test('YouTube transcript panel button clicks the native transcript control', asy
   await Promise.resolve();
 
   assert.equal(nativeTranscriptClicked, true);
+  assert.equal(dom.window.document.getElementById('chatgpt-web-injector-youtube-status'), null);
+});
+
+test('YouTube transcript panel button opens when stale transcript DOM is hidden', async () => {
+  const dom = new JSDOM(`
+    <html>
+      <body>
+        <div class="ytp-chrome-controls">
+          <button class="ytp-subtitles-button" aria-pressed="false">CC</button>
+        </div>
+        <ytd-engagement-panel-section-list-renderer visibility="ENGAGEMENT_PANEL_VISIBILITY_HIDDEN">
+          <ytd-transcript-segment-renderer>
+            <span class="segment-timestamp">0:01</span>
+            <span class="segment-text">Stale closed transcript</span>
+          </ytd-transcript-segment-renderer>
+        </ytd-engagement-panel-section-list-renderer>
+        <button aria-label="Show transcript">Show transcript</button>
+      </body>
+    </html>
+  `, {
+    runScripts: 'outside-only',
+    url: 'https://www.youtube.com/watch?v=test123',
+  });
+
+  let nativeTranscriptClicked = false;
+  dom.window.document.querySelector('[aria-label="Show transcript"]').addEventListener('click', () => {
+    nativeTranscriptClicked = true;
+  });
+
+  loadYoutubeSummary(dom);
+
+  const button = dom.window.document.getElementById('chatgpt-web-injector-youtube-transcript');
+  button.click();
+  await Promise.resolve();
+
+  assert.equal(nativeTranscriptClicked, true);
+  assert.equal(dom.window.document.getElementById('chatgpt-web-injector-youtube-status'), null);
+});
+
+test('YouTube transcript panel button closes an open transcript panel', async () => {
+  const dom = new JSDOM(`
+    <html>
+      <body>
+        <div class="ytp-chrome-controls">
+          <button class="ytp-subtitles-button" aria-pressed="false">CC</button>
+        </div>
+        <ytd-engagement-panel-section-list-renderer>
+          <button aria-label="Close transcript">Close</button>
+          <ytd-transcript-segment-renderer>
+            <span class="segment-timestamp">0:01</span>
+            <span class="segment-text">Open transcript</span>
+          </ytd-transcript-segment-renderer>
+        </ytd-engagement-panel-section-list-renderer>
+        <button aria-label="Show transcript">Show transcript</button>
+      </body>
+    </html>
+  `, {
+    runScripts: 'outside-only',
+    url: 'https://www.youtube.com/watch?v=test123',
+  });
+
+  let closeClicked = false;
+  dom.window.document.querySelector('[aria-label="Close transcript"]').addEventListener('click', () => {
+    closeClicked = true;
+  });
+
+  loadYoutubeSummary(dom);
+
+  const button = dom.window.document.getElementById('chatgpt-web-injector-youtube-transcript');
+  button.click();
+  await Promise.resolve();
+
+  assert.equal(closeClicked, true);
+  assert.equal(dom.window.document.getElementById('chatgpt-web-injector-youtube-status'), null);
 });
 
 test('YouTube summary keeps hour timestamps when reading visible transcript DOM', async () => {


### PR DESCRIPTION
## Summary
- make the YouTube TR button silently toggle the native transcript sidebar open and closed
- ignore hidden/stale transcript DOM when deciding whether the panel is open
- add regression coverage for stale hidden transcript panels and close-button behavior

Closes #38

## Tests
- node --check src/youtube_summary.js
- node --test tests/youtube_summary.test.js
- npm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced transcript visibility detection to accurately identify when transcripts are displayed
  * Improved handling of transcript panel states and unavailability scenarios

* **New Features**
  * Transcript panel now supports toggle functionality to open and close transcripts

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/qcwssss/chatgpt-web-injector/pull/40)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->