### PR TITLE
fix: restore YouTube transcript fallback

### DIFF
--- a/src/youtube_summary.js
+++ b/src/youtube_summary.js
@@ -262,7 +262,17 @@ function findTranscriptPanel() {
   ].join(', ')) || segment.parentElement;
 }
 
-function findTranscriptButton() {
+function isHiddenTranscriptPanelButton(button) {
+  const panel = button.closest([
+    'ytd-engagement-panel-section-list-renderer',
+    'ytd-transcript-renderer',
+    'ytd-transcript-search-panel-renderer',
+  ].join(', '));
+
+  return Boolean(panel && !isElementVisible(panel));
+}
+
+function findTranscriptButton({ allowHidden = false } = {}) {
   const labelPattern = /show transcript|transcript|文字稿|转录|轉錄|逐字稿|转写文稿|內容轉文字|内容转文字/i;
   const buttons = Array.from(document.querySelectorAll('button'));
 
@@ -270,7 +280,8 @@ function findTranscriptButton() {
     if (
       button.id === YOUTUBE_SUMMARY_BUTTON_ID ||
       button.id === YOUTUBE_TRANSCRIPT_BUTTON_ID ||
-      !isElementVisible(button)
+      isHiddenTranscriptPanelButton(button) ||
+      (!allowHidden && !isElementVisible(button))
     ) {
       return false;
     }
@@ -328,11 +339,11 @@ async function waitForTranscriptDom() {
 
 async function waitForTranscriptButton() {
   const startedAt = Date.now();
-  let transcriptButton = findTranscriptButton();
+  let transcriptButton = findTranscriptButton() || findTranscriptButton({ allowHidden: true });
 
   while (!transcriptButton && Date.now() - startedAt < TRANSCRIPT_DOM_WAIT_MS) {
     await new Promise((resolve) => { setTimeout(resolve, TRANSCRIPT_DOM_POLL_MS); });
-    transcriptButton = findTranscriptButton();
+    transcriptButton = findTranscriptButton() || findTranscriptButton({ allowHidden: true });
   }
 
   return transcriptButton;

--- a/tests/youtube_summary.test.js
+++ b/tests/youtube_summary.test.js
@@ -121,6 +121,46 @@ test('YouTube transcript panel button opens when stale transcript DOM is hidden'
   assert.equal(dom.window.document.getElementById('chatgpt-web-injector-youtube-status'), null);
 });
 
+test('YouTube transcript panel button falls back to a hidden native transcript control', async () => {
+  const dom = new JSDOM(`
+    <html>
+      <body>
+        <div class="ytp-chrome-controls">
+          <button class="ytp-subtitles-button" aria-pressed="false">CC</button>
+        </div>
+        <ytd-engagement-panel-section-list-renderer visibility="ENGAGEMENT_PANEL_VISIBILITY_HIDDEN">
+          <button aria-label="Show transcript">Stale panel transcript</button>
+        </ytd-engagement-panel-section-list-renderer>
+        <div hidden>
+          <button aria-label="Show transcript">Native transcript</button>
+        </div>
+      </body>
+    </html>
+  `, {
+    runScripts: 'outside-only',
+    url: 'https://www.youtube.com/watch?v=test123',
+  });
+
+  let staleTranscriptClicked = false;
+  let nativeTranscriptClicked = false;
+  dom.window.document.querySelector('ytd-engagement-panel-section-list-renderer button').addEventListener('click', () => {
+    staleTranscriptClicked = true;
+  });
+  dom.window.document.querySelector('div[hidden] button').addEventListener('click', () => {
+    nativeTranscriptClicked = true;
+  });
+
+  loadYoutubeSummary(dom);
+
+  const button = dom.window.document.getElementById('chatgpt-web-injector-youtube-transcript');
+  button.click();
+  await Promise.resolve();
+
+  assert.equal(staleTranscriptClicked, false);
+  assert.equal(nativeTranscriptClicked, true);
+  assert.equal(dom.window.document.getElementById('chatgpt-web-injector-youtube-status'), null);
+});
+
 test('YouTube transcript panel button closes an open transcript panel', async () => {
   const dom = new JSDOM(`
     <html>
@@ -241,6 +281,56 @@ test('YouTube summary keeps hour timestamps when reading visible transcript DOM'
   await new Promise((resolve) => { setTimeout(resolve, 20); });
 
   assert.equal(messages[0].payload.transcript, '[01:05:30] Past the first hour');
+});
+
+test('YouTube summary reads transcript after opening a hidden native transcript control', async () => {
+  const messages = [];
+  const dom = new JSDOM(`
+    <html>
+      <body>
+        <h1 class="ytd-watch-metadata">Fallback video</h1>
+        <div class="ytp-chrome-controls">
+          <button class="ytp-subtitles-button" aria-pressed="false">CC</button>
+        </div>
+        <div hidden>
+          <button aria-label="Show transcript">Native transcript</button>
+        </div>
+      </body>
+    </html>
+  `, {
+    runScripts: 'outside-only',
+    url: 'https://www.youtube.com/watch?v=test123',
+  });
+
+  dom.window.fetch = async () => {
+    throw new Error('network unavailable');
+  };
+  dom.window.document.querySelector('[aria-label="Show transcript"]').addEventListener('click', () => {
+    const panel = dom.window.document.createElement('ytd-engagement-panel-section-list-renderer');
+    panel.innerHTML = `
+      <ytd-transcript-segment-renderer>
+        <span class="segment-timestamp">0:05</span>
+        <span class="segment-text">Fallback transcript line</span>
+      </ytd-transcript-segment-renderer>
+    `;
+    dom.window.document.body.append(panel);
+  });
+
+  const chromeMock = {
+    runtime: {
+      sendMessage(message) {
+        messages.push(message);
+      },
+    },
+  };
+
+  loadYoutubeSummary(dom, { sendMessage: chromeMock.runtime.sendMessage });
+  dom.window.chrome = chromeMock;
+
+  dom.window.document.getElementById('chatgpt-web-injector-youtube-summary').click();
+  await new Promise((resolve) => { setTimeout(resolve, 250); });
+
+  assert.equal(messages[0].payload.transcript, '[00:05] Fallback transcript line');
 });
 
 test('loadYoutubeSummary restores chrome when script loading fails', () => {


### PR DESCRIPTION
## Summary
- allow the YouTube transcript opener to fall back to hidden native transcript controls when no visible opener is available
- keep skipping stale hidden transcript-panel buttons so reopen does not click dead panel controls
- add coverage for both TR open fallback and AI summary DOM transcript fallback

## Tests
- node --check src/youtube_summary.js
- node --test tests/youtube_summary.test.js
- npm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved YouTube transcript detection to reliably locate transcript controls even when the panel is hidden or not immediately visible on screen. Enhanced transcript reading functionality for edge cases where the UI exists but is not displayed during initial load.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/qcwssss/chatgpt-web-injector/pull/41)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->