### PR TITLE
fix: continue after ChatGPT tab load timeout

### DIFF
--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -1,0 +1,28 @@
+# Privacy Policy for ChatGPT Web Injector
+
+**Last Updated: May 13, 2026**
+
+## 1. Information We Collect
+The "ChatGPT Web Injector" extension is designed with your privacy as the primary focus. 
+The extension only accesses the text you explicitly select on webpages, the page URL, and the page title. 
+It does this strictly for the purpose of sending the context to ChatGPT or summarizing YouTube transcripts.
+
+## 2. How We Use Your Information
+All data processing occurs locally within your browser and directly between your browser and the ChatGPT website (`chatgpt.com`). 
+We **do not** collect, store, or transmit your data to any of our own servers or third-party servers (other than OpenAI's servers when you explicitly send a prompt). We do not maintain any backend databases for this extension.
+
+## 3. Data Sharing and Disclosure
+We **do not** sell, trade, or otherwise transfer your personal information to outside parties. Your data remains completely under your control and is only sent to OpenAI's ChatGPT when you initiate an action (like clicking the "Send to ChatGPT" button, using the context menu, or requesting a YouTube summary).
+
+## 4. Permissions Justification
+- **Context Menus**: To provide the right-click option for sending selected text.
+- **Storage**: To save your custom prompt templates locally on your device.
+- **Tabs / ActiveTab**: To open or interact with the ChatGPT page and read the current page's selected text.
+- **Scripting**: To automate the process of inserting text into the ChatGPT interface.
+- **Host Permissions (`<all_urls>`, `https://chatgpt.com/*`)**: To allow the extension to inject the selection tooltip on websites you visit and to interact with the ChatGPT interface.
+
+## 5. Changes to This Privacy Policy
+We may update our Privacy Policy from time to time. Any changes will be reflected in this document.
+
+## 6. Contact Us
+If you have any questions or suggestions about our Privacy Policy, please feel free to create an issue in our GitHub repository.

--- a/src/service_worker.js
+++ b/src/service_worker.js
@@ -97,7 +97,7 @@ export async function executeChatgptSendFlow(tabId, prompt, options = {}) {
         throw error;
       }
 
-      await waitForTabComplete(tabId, TAB_WAIT_TIMEOUT_MS);
+      await waitForChatgptTabReady(tabId);
       await new Promise((resolve) => { setTimeout(resolve, injectRetryMs); });
     }
   }
@@ -105,6 +105,12 @@ export async function executeChatgptSendFlow(tabId, prompt, options = {}) {
   throw new Error('chatgpt_injection_failed');
 }
 
+/**
+ * Waits for the ChatGPT tab to be ready.
+ * @param {number|string} tabId - The identifier of the tab.
+ * @param {number} [timeoutMs=TAB_WAIT_TIMEOUT_MS] - Optional timeout in milliseconds.
+ * @returns {Promise<void>} Resolves when the tab is ready or continues after a tab_load_timeout.
+ */
 export async function waitForChatgptTabReady(tabId, timeoutMs = TAB_WAIT_TIMEOUT_MS) {
   try {
     await waitForTabComplete(tabId, timeoutMs);
@@ -132,7 +138,7 @@ async function sendWithTemplate(templateId, selectionText, tab) {
 async function sendPromptToChatgpt(prompt, options = {}) {
   const targetUrl = getChatgptTargetUrl(options.preferTemporaryChat === true);
   const targetTab = await chrome.tabs.create({ url: targetUrl, active: true });
-  await waitForChatgptTabReady(targetTab.id, TAB_WAIT_TIMEOUT_MS);
+  await waitForChatgptTabReady(targetTab.id);
 
   const result = await executeChatgptSendFlow(targetTab.id, prompt, {
     maxAttempts: 24,

--- a/src/service_worker.js
+++ b/src/service_worker.js
@@ -105,6 +105,18 @@ export async function executeChatgptSendFlow(tabId, prompt, options = {}) {
   throw new Error('chatgpt_injection_failed');
 }
 
+export async function waitForChatgptTabReady(tabId, timeoutMs = TAB_WAIT_TIMEOUT_MS) {
+  try {
+    await waitForTabComplete(tabId, timeoutMs);
+  } catch (error) {
+    if (error?.message !== 'tab_load_timeout') {
+      throw error;
+    }
+
+    console.warn('[ChatGPT Web Injector] ChatGPT tab load timed out, continuing injection:', error);
+  }
+}
+
 async function sendWithTemplate(templateId, selectionText, tab) {
   const payload = {
     selection: selectionText || '',
@@ -120,7 +132,7 @@ async function sendWithTemplate(templateId, selectionText, tab) {
 async function sendPromptToChatgpt(prompt, options = {}) {
   const targetUrl = getChatgptTargetUrl(options.preferTemporaryChat === true);
   const targetTab = await chrome.tabs.create({ url: targetUrl, active: true });
-  await waitForTabComplete(targetTab.id, TAB_WAIT_TIMEOUT_MS);
+  await waitForChatgptTabReady(targetTab.id, TAB_WAIT_TIMEOUT_MS);
 
   const result = await executeChatgptSendFlow(targetTab.id, prompt, {
     maxAttempts: 24,

--- a/tests/service_worker.test.js
+++ b/tests/service_worker.test.js
@@ -41,6 +41,7 @@ const {
   executeChatgptSendFlow,
   getChatgptTargetUrl,
   waitForTabComplete,
+  waitForChatgptTabReady,
 } = await import('../src/service_worker.js');
 
 after(() => {
@@ -66,6 +67,22 @@ test('waitForTabComplete rejects when the tab cannot be read', async () => {
     await assert.rejects(() => waitForTabComplete(456, 100), /No tab with id: 456/);
   } finally {
     globalThis.chrome.tabs.get = originalGet;
+  }
+});
+
+test('waitForChatgptTabReady continues when ChatGPT tab load times out', async () => {
+  const originalGet = globalThis.chrome.tabs.get;
+  const originalWarn = console.warn;
+  globalThis.chrome.tabs.get = async (tabId) => {
+    return { id: tabId, status: 'loading' };
+  };
+  console.warn = () => {};
+
+  try {
+    await waitForChatgptTabReady(123, 1);
+  } finally {
+    globalThis.chrome.tabs.get = originalGet;
+    console.warn = originalWarn;
   }
 });
 


### PR DESCRIPTION
## Summary
- treat ChatGPT tab load timeout as non-fatal before prompt injection
- continue into the existing injection flow, which already waits for the composer
- add service worker coverage for tab load timeout handling

## Tests
- node --check src/service_worker.js
- node --test tests/service_worker.test.js
- npm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ChatGPT integration resilience: sending prompts now continues when target tabs exceed load time, reducing failed attempts and interruptions.

* **Documentation**
  * Added a privacy policy outlining collected data, processing/transmission to ChatGPT, requested permissions, update notices, and contact instructions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/qcwssss/chatgpt-web-injector/pull/42)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->