### PR TITLE
fix: avoid clicking YouTube transcript segments

### DIFF
--- a/src/youtube_summary.js
+++ b/src/youtube_summary.js
@@ -270,6 +270,15 @@ function panelHasTranscriptContent(panel) {
     return false;
   }
 
+  const targetId = panel.getAttribute('target-id');
+  if (targetId === 'engagement-panel-transcript') {
+    return true;
+  }
+
+  if (targetId && !targetId.includes('transcript')) {
+    return false;
+  }
+
   if (
     panel.matches(TRANSCRIPT_PANEL_SELECTOR) ||
     panel.querySelector([

--- a/src/youtube_summary.js
+++ b/src/youtube_summary.js
@@ -9,6 +9,14 @@ const MOUNT_DEBOUNCE_MS = 150;
 const OBSERVER_RETRY_MS = 500;
 const TRANSCRIPT_DOM_WAIT_MS = 3000;
 const TRANSCRIPT_DOM_POLL_MS = 200;
+const TRANSCRIPT_PANEL_SELECTOR = [
+  'ytd-transcript-renderer',
+  'ytd-transcript-search-panel-renderer',
+].join(', ');
+const TRANSCRIPT_SEGMENT_SELECTOR = [
+  'ytd-transcript-segment-renderer',
+  'transcript-segment-view-model',
+].join(', ');
 const DEBUG = false;
 
 let lastUrl = '';
@@ -241,19 +249,46 @@ function readTranscriptFromDom() {
 }
 
 function findVisibleTranscriptSegment() {
-  const selectors = [
-    'ytd-transcript-segment-renderer',
-    'transcript-segment-view-model',
-  ].join(', ');
-  return Array.from(document.querySelectorAll(selectors))
+  return Array.from(document.querySelectorAll(TRANSCRIPT_SEGMENT_SELECTOR))
     .find((segment) => isElementVisible(segment)) || null;
+}
+
+function getButtonLabel(button) {
+  return [
+    button.getAttribute('aria-label') || '',
+    button.getAttribute('title') || '',
+    button.textContent || '',
+  ].join(' ');
+}
+
+function isTranscriptSegmentControl(button) {
+  return /\b\d{1,2}:\d{2}(?::\d{2})?\b/.test(getButtonLabel(button));
+}
+
+function panelHasTranscriptContent(panel) {
+  if (!panel) {
+    return false;
+  }
+
+  if (
+    panel.matches(TRANSCRIPT_PANEL_SELECTOR) ||
+    panel.querySelector([
+      TRANSCRIPT_PANEL_SELECTOR,
+      TRANSCRIPT_SEGMENT_SELECTOR,
+    ].join(', '))
+  ) {
+    return true;
+  }
+
+  return Array.from(panel.querySelectorAll('button, [role="button"]'))
+    .some((button) => isTranscriptSegmentControl(button));
 }
 
 function findTranscriptPanel() {
   const segment = findVisibleTranscriptSegment();
   if (!segment) {
     return Array.from(document.querySelectorAll('ytd-engagement-panel-section-list-renderer'))
-      .find((panel) => isElementVisible(panel)) || null;
+      .find((panel) => isElementVisible(panel) && panelHasTranscriptContent(panel)) || null;
   }
 
   return segment.closest([
@@ -264,13 +299,17 @@ function findTranscriptPanel() {
 }
 
 function isTranscriptPanelButton(button) {
-  const panel = button.closest([
-    'ytd-engagement-panel-section-list-renderer',
-    'ytd-transcript-renderer',
-    'ytd-transcript-search-panel-renderer',
-  ].join(', '));
+  const transcriptContainer = button.closest(TRANSCRIPT_PANEL_SELECTOR);
+  if (transcriptContainer) {
+    return true;
+  }
 
-  return Boolean(panel);
+  const panel = button.closest('ytd-engagement-panel-section-list-renderer');
+  if (panel && !isElementVisible(panel)) {
+    return true;
+  }
+
+  return panelHasTranscriptContent(panel);
 }
 
 function findTranscriptButton({ allowHidden = false } = {}) {
@@ -287,11 +326,7 @@ function findTranscriptButton({ allowHidden = false } = {}) {
       return false;
     }
 
-    const label = [
-      button.getAttribute('aria-label') || '',
-      button.textContent || '',
-    ].join(' ');
-    return labelPattern.test(label);
+    return labelPattern.test(getButtonLabel(button));
   }) || null;
 }
 

--- a/src/youtube_summary.js
+++ b/src/youtube_summary.js
@@ -252,7 +252,8 @@ function findVisibleTranscriptSegment() {
 function findTranscriptPanel() {
   const segment = findVisibleTranscriptSegment();
   if (!segment) {
-    return null;
+    return Array.from(document.querySelectorAll('ytd-engagement-panel-section-list-renderer'))
+      .find((panel) => isElementVisible(panel)) || null;
   }
 
   return segment.closest([
@@ -262,14 +263,14 @@ function findTranscriptPanel() {
   ].join(', ')) || segment.parentElement;
 }
 
-function isHiddenTranscriptPanelButton(button) {
+function isTranscriptPanelButton(button) {
   const panel = button.closest([
     'ytd-engagement-panel-section-list-renderer',
     'ytd-transcript-renderer',
     'ytd-transcript-search-panel-renderer',
   ].join(', '));
 
-  return Boolean(panel && !isElementVisible(panel));
+  return Boolean(panel);
 }
 
 function findTranscriptButton({ allowHidden = false } = {}) {
@@ -280,7 +281,7 @@ function findTranscriptButton({ allowHidden = false } = {}) {
     if (
       button.id === YOUTUBE_SUMMARY_BUTTON_ID ||
       button.id === YOUTUBE_TRANSCRIPT_BUTTON_ID ||
-      isHiddenTranscriptPanelButton(button) ||
+      isTranscriptPanelButton(button) ||
       (!allowHidden && !isElementVisible(button))
     ) {
       return false;

--- a/src/youtube_summary.js
+++ b/src/youtube_summary.js
@@ -318,6 +318,8 @@ function findTranscriptCloseButton(panel = findTranscriptPanel()) {
     }
 
     const label = [
+      button.id || '',
+      button.className || '',
       button.getAttribute('aria-label') || '',
       button.getAttribute('title') || '',
       button.textContent || '',

--- a/tests/youtube_summary.test.js
+++ b/tests/youtube_summary.test.js
@@ -274,6 +274,44 @@ test('YouTube transcript panel button does not click transcript segment buttons 
   assert.equal(dom.window.document.getElementById('chatgpt-web-injector-youtube-status')?.textContent, 'Transcript unavailable');
 });
 
+test('YouTube transcript panel button ignores visible non-transcript engagement panels', async () => {
+  const dom = new JSDOM(`
+    <html>
+      <body>
+        <div class="ytp-chrome-controls">
+          <button class="ytp-subtitles-button" aria-pressed="false">CC</button>
+        </div>
+        <ytd-engagement-panel-section-list-renderer visibility="ENGAGEMENT_PANEL_VISIBILITY_EXPANDED">
+          <button aria-label="Open comments">Comments</button>
+        </ytd-engagement-panel-section-list-renderer>
+        <button aria-label="Show transcript">Show transcript</button>
+      </body>
+    </html>
+  `, {
+    runScripts: 'outside-only',
+    url: 'https://www.youtube.com/watch?v=test123',
+  });
+
+  let commentsClicked = false;
+  let showClicked = false;
+  dom.window.document.querySelector('[aria-label="Open comments"]').addEventListener('click', () => {
+    commentsClicked = true;
+  });
+  dom.window.document.body.lastElementChild.addEventListener('click', () => {
+    showClicked = true;
+  });
+
+  loadYoutubeSummary(dom);
+
+  const button = dom.window.document.getElementById('chatgpt-web-injector-youtube-transcript');
+  button.click();
+  await Promise.resolve();
+
+  assert.equal(commentsClicked, false);
+  assert.equal(showClicked, true);
+  assert.equal(dom.window.document.getElementById('chatgpt-web-injector-youtube-status'), null);
+});
+
 test('YouTube transcript panel button reopens after closing the transcript panel', async () => {
   const dom = new JSDOM(`
     <html>

--- a/tests/youtube_summary.test.js
+++ b/tests/youtube_summary.test.js
@@ -198,6 +198,44 @@ test('YouTube transcript panel button closes an open transcript panel', async ()
   assert.equal(dom.window.document.getElementById('chatgpt-web-injector-youtube-status'), null);
 });
 
+test('YouTube transcript panel button closes an open transcript panel with an unlabeled dismiss button', async () => {
+  const dom = new JSDOM(`
+    <html>
+      <body>
+        <div class="ytp-chrome-controls">
+          <button class="ytp-subtitles-button" aria-pressed="false">CC</button>
+        </div>
+        <ytd-engagement-panel-section-list-renderer visibility="ENGAGEMENT_PANEL_VISIBILITY_EXPANDED">
+          <button id="dismiss-button"></button>
+          <button aria-label="0:05 transcript segment">Transcript segment</button>
+        </ytd-engagement-panel-section-list-renderer>
+      </body>
+    </html>
+  `, {
+    runScripts: 'outside-only',
+    url: 'https://www.youtube.com/watch?v=test123',
+  });
+
+  let closeClicked = false;
+  let segmentClicked = false;
+  dom.window.document.getElementById('dismiss-button').addEventListener('click', () => {
+    closeClicked = true;
+  });
+  dom.window.document.querySelector('[aria-label="0:05 transcript segment"]').addEventListener('click', () => {
+    segmentClicked = true;
+  });
+
+  loadYoutubeSummary(dom);
+
+  const button = dom.window.document.getElementById('chatgpt-web-injector-youtube-transcript');
+  button.click();
+  await Promise.resolve();
+
+  assert.equal(closeClicked, true);
+  assert.equal(segmentClicked, false);
+  assert.equal(dom.window.document.getElementById('chatgpt-web-injector-youtube-status'), null);
+});
+
 test('YouTube transcript panel button does not click transcript segment buttons when panel is open', async () => {
   const dom = new JSDOM(`
     <html>

--- a/tests/youtube_summary.test.js
+++ b/tests/youtube_summary.test.js
@@ -198,6 +198,44 @@ test('YouTube transcript panel button closes an open transcript panel', async ()
   assert.equal(dom.window.document.getElementById('chatgpt-web-injector-youtube-status'), null);
 });
 
+test('YouTube transcript panel button does not click transcript segment buttons when panel is open', async () => {
+  const dom = new JSDOM(`
+    <html>
+      <body>
+        <div class="ytp-chrome-controls">
+          <button class="ytp-subtitles-button" aria-pressed="false">CC</button>
+        </div>
+        <ytd-engagement-panel-section-list-renderer visibility="ENGAGEMENT_PANEL_VISIBILITY_EXPANDED">
+          <button aria-label="0:05 transcript segment">Transcript segment</button>
+        </ytd-engagement-panel-section-list-renderer>
+        <button aria-label="Show transcript">Show transcript</button>
+      </body>
+    </html>
+  `, {
+    runScripts: 'outside-only',
+    url: 'https://www.youtube.com/watch?v=test123',
+  });
+
+  let segmentClicked = false;
+  let showClicked = false;
+  dom.window.document.querySelector('[aria-label="0:05 transcript segment"]').addEventListener('click', () => {
+    segmentClicked = true;
+  });
+  dom.window.document.body.lastElementChild.addEventListener('click', () => {
+    showClicked = true;
+  });
+
+  loadYoutubeSummary(dom);
+
+  const button = dom.window.document.getElementById('chatgpt-web-injector-youtube-transcript');
+  button.click();
+  await Promise.resolve();
+
+  assert.equal(segmentClicked, false);
+  assert.equal(showClicked, false);
+  assert.equal(dom.window.document.getElementById('chatgpt-web-injector-youtube-status')?.textContent, 'Transcript unavailable');
+});
+
 test('YouTube transcript panel button reopens after closing the transcript panel', async () => {
   const dom = new JSDOM(`
     <html>


### PR DESCRIPTION
## Summary
- treat visible YouTube engagement panels as open transcript panels even when segment tags are not present
- exclude all buttons inside transcript panels from transcript opener discovery
- add regression coverage to ensure TR does not click transcript segment buttons and seek the video

## Tests
- node --check src/youtube_summary.js
- node --test tests/youtube_summary.test.js
- npm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable transcript panel detection with a fallback when no visible transcript segment is found
  * Expanded recognition of transcript close/dismiss controls (now considers more label sources)
  * Ignore non-transcript engagement panels so injected controls don't trigger unrelated content

* **Tests**
  * Added tests verifying injected control behavior: dismissal handling, avoiding accidental transcript-segment clicks, and correct fallback behavior when transcript unavailable

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/qcwssss/chatgpt-web-injector/pull/43)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->