### PR TITLE
fix: resolve transcript button not found in hidden description panels

### DIFF
--- a/src/youtube_summary.js
+++ b/src/youtube_summary.js
@@ -314,13 +314,17 @@ function isTranscriptPanelButton(button) {
   }
 
   const panel = button.closest('ytd-engagement-panel-section-list-renderer');
+  if (panel && !isElementVisible(panel)) {
+    return true;
+  }
+
   return panelHasTranscriptContent(panel);
 }
 
 function findTranscriptButton({ allowHidden = false } = {}) {
   const labelPattern = /show transcript|transcript|文字稿|转录|轉錄|逐字稿|转写文稿|內容轉文字|内容转文字/i;
   // 扩大查找范围：包含 button 标签和常见的 YouTube 自定义按钮元素
-  const buttons = Array.from(document.querySelectorAll('button, tp-yt-paper-button, [role="button"]'));
+  const buttons = Array.from(document.querySelectorAll('button, tp-yt-paper-button, ytd-button-renderer, [role="button"]'));
 
   return buttons.find((button) => {
     if (
@@ -338,23 +342,26 @@ function findTranscriptButton({ allowHidden = false } = {}) {
 
 function expandDescription() {
   const container = document.querySelector('ytd-watch-metadata') || document.querySelector('ytd-video-secondary-info-renderer');
-  if (!container) return;
+  if (!container) {
+    return;
+  }
 
   const expandPattern = /\.\.\.more|show more|展开|展開|顯示更多|显示更多/i;
-  const expandElements = container.querySelectorAll('tp-yt-paper-button, button, [id="expand"], ytd-button-renderer, div[role="button"]');
-  
+  const expandElements = container.querySelectorAll('tp-yt-paper-button, button, [id="expand"], ytd-button-renderer, [role="button"]');
+
   for (const el of expandElements) {
     const text = (el.textContent || '').trim();
-    if (expandPattern.test(text) && isElementVisible(el)) {
+    if (
+      expandPattern.test(text) &&
+      isElementVisible(el) &&
+      el.getAttribute('aria-expanded') !== 'true'
+    ) {
       el.click();
-      return;
+      return true;
     }
   }
-  
-  const oldExpand = container.querySelector('#expand');
-  if (oldExpand && isElementVisible(oldExpand)) {
-    oldExpand.click();
-  }
+
+  return false;
 }
 
 function findTranscriptCloseButton(panel = findTranscriptPanel()) {
@@ -405,13 +412,15 @@ async function waitForTranscriptDom() {
 async function waitForTranscriptButton() {
   const startedAt = Date.now();
   let transcriptButton = findTranscriptButton() || findTranscriptButton({ allowHidden: true });
+  let descriptionExpanded = false;
 
   while (!transcriptButton && Date.now() - startedAt < TRANSCRIPT_DOM_WAIT_MS) {
     await new Promise((resolve) => { setTimeout(resolve, TRANSCRIPT_DOM_POLL_MS); });
     
     // 如果找了一半的时间还没找到，尝试展开视频描述框，因为按钮可能被隐藏且未渲染
-    if (!transcriptButton && Date.now() - startedAt > (TRANSCRIPT_DOM_WAIT_MS / 2)) {
+    if (!transcriptButton && !descriptionExpanded && Date.now() - startedAt > (TRANSCRIPT_DOM_WAIT_MS / 2)) {
       expandDescription();
+      descriptionExpanded = true;
     }
     
     transcriptButton = findTranscriptButton() || findTranscriptButton({ allowHidden: true });

--- a/src/youtube_summary.js
+++ b/src/youtube_summary.js
@@ -323,7 +323,7 @@ function isTranscriptPanelButton(button) {
 
 function findTranscriptButton({ allowHidden = false } = {}) {
   const labelPattern = /show transcript|transcript|文字稿|转录|轉錄|逐字稿|转写文稿|內容轉文字|内容转文字/i;
-  // 扩大查找范围：包含 button 标签和常见的 YouTube 自定义按钮元素
+  // Expand search scope: include standard button tags and common YouTube custom button elements
   const buttons = Array.from(document.querySelectorAll('button, tp-yt-paper-button, ytd-button-renderer, [role="button"]'));
 
   return buttons.find((button) => {
@@ -417,10 +417,9 @@ async function waitForTranscriptButton() {
   while (!transcriptButton && Date.now() - startedAt < TRANSCRIPT_DOM_WAIT_MS) {
     await new Promise((resolve) => { setTimeout(resolve, TRANSCRIPT_DOM_POLL_MS); });
     
-    // 如果找了一半的时间还没找到，尝试展开视频描述框，因为按钮可能被隐藏且未渲染
+    // Try to expand the video description if the button is not found within half the wait time, as it might be hidden and unrendered.
     if (!transcriptButton && !descriptionExpanded && Date.now() - startedAt > (TRANSCRIPT_DOM_WAIT_MS / 2)) {
-      expandDescription();
-      descriptionExpanded = true;
+      descriptionExpanded = expandDescription();
     }
     
     transcriptButton = findTranscriptButton() || findTranscriptButton({ allowHidden: true });

--- a/src/youtube_summary.js
+++ b/src/youtube_summary.js
@@ -314,16 +314,13 @@ function isTranscriptPanelButton(button) {
   }
 
   const panel = button.closest('ytd-engagement-panel-section-list-renderer');
-  if (panel && !isElementVisible(panel)) {
-    return true;
-  }
-
   return panelHasTranscriptContent(panel);
 }
 
 function findTranscriptButton({ allowHidden = false } = {}) {
   const labelPattern = /show transcript|transcript|文字稿|转录|轉錄|逐字稿|转写文稿|內容轉文字|内容转文字/i;
-  const buttons = Array.from(document.querySelectorAll('button'));
+  // 扩大查找范围：包含 button 标签和常见的 YouTube 自定义按钮元素
+  const buttons = Array.from(document.querySelectorAll('button, tp-yt-paper-button, [role="button"]'));
 
   return buttons.find((button) => {
     if (
@@ -337,6 +334,27 @@ function findTranscriptButton({ allowHidden = false } = {}) {
 
     return labelPattern.test(getButtonLabel(button));
   }) || null;
+}
+
+function expandDescription() {
+  const container = document.querySelector('ytd-watch-metadata') || document.querySelector('ytd-video-secondary-info-renderer');
+  if (!container) return;
+
+  const expandPattern = /\.\.\.more|show more|展开|展開|顯示更多|显示更多/i;
+  const expandElements = container.querySelectorAll('tp-yt-paper-button, button, [id="expand"], ytd-button-renderer, div[role="button"]');
+  
+  for (const el of expandElements) {
+    const text = (el.textContent || '').trim();
+    if (expandPattern.test(text) && isElementVisible(el)) {
+      el.click();
+      return;
+    }
+  }
+  
+  const oldExpand = container.querySelector('#expand');
+  if (oldExpand && isElementVisible(oldExpand)) {
+    oldExpand.click();
+  }
 }
 
 function findTranscriptCloseButton(panel = findTranscriptPanel()) {
@@ -390,6 +408,12 @@ async function waitForTranscriptButton() {
 
   while (!transcriptButton && Date.now() - startedAt < TRANSCRIPT_DOM_WAIT_MS) {
     await new Promise((resolve) => { setTimeout(resolve, TRANSCRIPT_DOM_POLL_MS); });
+    
+    // 如果找了一半的时间还没找到，尝试展开视频描述框，因为按钮可能被隐藏且未渲染
+    if (!transcriptButton && Date.now() - startedAt > (TRANSCRIPT_DOM_WAIT_MS / 2)) {
+      expandDescription();
+    }
+    
     transcriptButton = findTranscriptButton() || findTranscriptButton({ allowHidden: true });
   }
 

--- a/src/youtube_summary.js
+++ b/src/youtube_summary.js
@@ -321,23 +321,36 @@ function isTranscriptPanelButton(button) {
   return panelHasTranscriptContent(panel);
 }
 
+function getActionableTranscriptButton(button) {
+  if (button.tagName !== 'YTD-BUTTON-RENDERER') {
+    return button;
+  }
+
+  return button.querySelector('button, tp-yt-paper-button, [role="button"]') || button;
+}
+
 function findTranscriptButton({ allowHidden = false } = {}) {
   const labelPattern = /show transcript|transcript|文字稿|转录|轉錄|逐字稿|转写文稿|內容轉文字|内容转文字/i;
   // Expand search scope: include standard button tags and common YouTube custom button elements
   const buttons = Array.from(document.querySelectorAll('button, tp-yt-paper-button, ytd-button-renderer, [role="button"]'));
 
-  return buttons.find((button) => {
+  for (const button of buttons) {
+    const actionableButton = getActionableTranscriptButton(button);
     if (
-      button.id === YOUTUBE_SUMMARY_BUTTON_ID ||
-      button.id === YOUTUBE_TRANSCRIPT_BUTTON_ID ||
-      isTranscriptPanelButton(button) ||
-      (!allowHidden && !isElementVisible(button))
+      actionableButton.id === YOUTUBE_SUMMARY_BUTTON_ID ||
+      actionableButton.id === YOUTUBE_TRANSCRIPT_BUTTON_ID ||
+      isTranscriptPanelButton(actionableButton) ||
+      (!allowHidden && !isElementVisible(actionableButton))
     ) {
-      return false;
+      continue;
     }
 
-    return labelPattern.test(getButtonLabel(button));
-  }) || null;
+    if (labelPattern.test(getButtonLabel(actionableButton))) {
+      return actionableButton;
+    }
+  }
+
+  return null;
 }
 
 function expandDescription() {
@@ -346,7 +359,7 @@ function expandDescription() {
     return;
   }
 
-  const expandPattern = /\.\.\.more|show more|展开|展開|顯示更多|显示更多/i;
+  const expandPattern = /\.\.\.(?:more|更多)|show more|展开|展開|顯示更多|显示更多/i;
   const expandElements = container.querySelectorAll('tp-yt-paper-button, button, [id="expand"], ytd-button-renderer, [role="button"]');
 
   for (const el of expandElements) {
@@ -411,21 +424,20 @@ async function waitForTranscriptDom() {
 
 async function waitForTranscriptButton() {
   const startedAt = Date.now();
-  let transcriptButton = findTranscriptButton() || findTranscriptButton({ allowHidden: true });
-  let descriptionExpanded = false;
+  let transcriptButton = findTranscriptButton();
+  const descriptionExpanded = expandDescription();
+
+  if (!transcriptButton && !descriptionExpanded) {
+    transcriptButton = findTranscriptButton({ allowHidden: true });
+  }
 
   while (!transcriptButton && Date.now() - startedAt < TRANSCRIPT_DOM_WAIT_MS) {
     await new Promise((resolve) => { setTimeout(resolve, TRANSCRIPT_DOM_POLL_MS); });
-    
-    // Try to expand the video description if the button is not found within half the wait time, as it might be hidden and unrendered.
-    if (!transcriptButton && !descriptionExpanded && Date.now() - startedAt > (TRANSCRIPT_DOM_WAIT_MS / 2)) {
-      descriptionExpanded = expandDescription();
-    }
-    
-    transcriptButton = findTranscriptButton() || findTranscriptButton({ allowHidden: true });
+
+    transcriptButton = findTranscriptButton();
   }
 
-  return transcriptButton;
+  return transcriptButton || findTranscriptButton({ allowHidden: true });
 }
 
 async function fetchTranscriptFromDom() {

--- a/tests/youtube_summary.test.js
+++ b/tests/youtube_summary.test.js
@@ -312,6 +312,51 @@ test('YouTube transcript panel button ignores visible non-transcript engagement 
   assert.equal(dom.window.document.getElementById('chatgpt-web-injector-youtube-status'), null);
 });
 
+test('YouTube transcript panel button expands description once before opening transcript', async () => {
+  const dom = new JSDOM(`
+    <html>
+      <body>
+        <div class="ytp-chrome-controls">
+          <button class="ytp-subtitles-button" aria-pressed="false">CC</button>
+        </div>
+        <ytd-watch-metadata>
+          <button id="expand" aria-expanded="false">Show more</button>
+        </ytd-watch-metadata>
+      </body>
+    </html>
+  `, {
+    runScripts: 'outside-only',
+    url: 'https://www.youtube.com/watch?v=test123',
+  });
+
+  let expandClicks = 0;
+  let nativeTranscriptClicked = false;
+  const expandButton = dom.window.document.getElementById('expand');
+  expandButton.addEventListener('click', () => {
+    expandClicks += 1;
+    expandButton.setAttribute('aria-expanded', 'true');
+    setTimeout(() => {
+      const transcriptButton = dom.window.document.createElement('button');
+      transcriptButton.setAttribute('aria-label', 'Show transcript');
+      transcriptButton.textContent = 'Show transcript';
+      transcriptButton.addEventListener('click', () => {
+        nativeTranscriptClicked = true;
+      });
+      dom.window.document.body.append(transcriptButton);
+    }, 300);
+  });
+
+  loadYoutubeSummary(dom);
+
+  const button = dom.window.document.getElementById('chatgpt-web-injector-youtube-transcript');
+  button.click();
+  await new Promise((resolve) => { setTimeout(resolve, 2200); });
+
+  assert.equal(expandClicks, 1);
+  assert.equal(nativeTranscriptClicked, true);
+  assert.equal(dom.window.document.getElementById('chatgpt-web-injector-youtube-status'), null);
+});
+
 test('YouTube transcript panel button reopens after closing the transcript panel', async () => {
   const dom = new JSDOM(`
     <html>

--- a/tests/youtube_summary.test.js
+++ b/tests/youtube_summary.test.js
@@ -79,6 +79,43 @@ test('YouTube transcript panel button clicks the native transcript control', asy
   assert.equal(dom.window.document.getElementById('chatgpt-web-injector-youtube-status'), null);
 });
 
+test('YouTube transcript panel button clicks the nested native button inside renderer wrappers', async () => {
+  const dom = new JSDOM(`
+    <html>
+      <body>
+        <div class="ytp-chrome-controls">
+          <button class="ytp-subtitles-button" aria-pressed="false">CC</button>
+        </div>
+        <ytd-button-renderer>
+          Show transcript
+          <button aria-label="Show transcript">Show transcript</button>
+        </ytd-button-renderer>
+      </body>
+    </html>
+  `, {
+    runScripts: 'outside-only',
+    url: 'https://www.youtube.com/watch?v=test123',
+  });
+
+  let wrapperClicked = false;
+  let nativeTranscriptClicked = false;
+  dom.window.document.querySelector('ytd-button-renderer').addEventListener('click', (event) => {
+    wrapperClicked = event.target.tagName === 'YTD-BUTTON-RENDERER';
+  });
+  dom.window.document.querySelector('ytd-button-renderer button').addEventListener('click', () => {
+    nativeTranscriptClicked = true;
+  });
+
+  loadYoutubeSummary(dom);
+
+  const button = dom.window.document.getElementById('chatgpt-web-injector-youtube-transcript');
+  button.click();
+  await Promise.resolve();
+
+  assert.equal(wrapperClicked, false);
+  assert.equal(nativeTranscriptClicked, true);
+});
+
 test('YouTube transcript panel button opens when stale transcript DOM is hidden', async () => {
   const dom = new JSDOM(`
     <html>
@@ -355,6 +392,52 @@ test('YouTube transcript panel button expands description once before opening tr
   assert.equal(expandClicks, 1);
   assert.equal(nativeTranscriptClicked, true);
   assert.equal(dom.window.document.getElementById('chatgpt-web-injector-youtube-status'), null);
+});
+
+test('YouTube transcript panel button expands Chinese collapsed description before using hidden controls', async () => {
+  const dom = new JSDOM(`
+    <html>
+      <body>
+        <div class="ytp-chrome-controls">
+          <button class="ytp-subtitles-button" aria-pressed="false">CC</button>
+        </div>
+        <ytd-watch-metadata>
+          <tp-yt-paper-button id="expand">...更多</tp-yt-paper-button>
+          <div hidden>
+            <button aria-label="内容转文字">Hidden transcript</button>
+          </div>
+        </ytd-watch-metadata>
+      </body>
+    </html>
+  `, {
+    runScripts: 'outside-only',
+    url: 'https://www.youtube.com/watch?v=test123',
+  });
+
+  let hiddenTranscriptClicked = false;
+  let visibleTranscriptClicked = false;
+  const expandButton = dom.window.document.getElementById('expand');
+  dom.window.document.querySelector('[aria-label="内容转文字"]').addEventListener('click', () => {
+    hiddenTranscriptClicked = true;
+  });
+  expandButton.addEventListener('click', () => {
+    const transcriptButton = dom.window.document.createElement('button');
+    transcriptButton.setAttribute('aria-label', '内容转文字');
+    transcriptButton.textContent = '内容转文字';
+    transcriptButton.addEventListener('click', () => {
+      visibleTranscriptClicked = true;
+    });
+    dom.window.document.body.append(transcriptButton);
+  });
+
+  loadYoutubeSummary(dom);
+
+  const button = dom.window.document.getElementById('chatgpt-web-injector-youtube-transcript');
+  button.click();
+  await new Promise((resolve) => { setTimeout(resolve, 250); });
+
+  assert.equal(hiddenTranscriptClicked, false);
+  assert.equal(visibleTranscriptClicked, true);
 });
 
 test('YouTube transcript panel button reopens after closing the transcript panel', async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Transcript detection now recognizes additional button-like elements and any control with role="button" for improved compatibility.
  * Video descriptions are automatically expanded when needed so hidden transcript controls are revealed; logic falls back to hidden-search only when expansion didn't occur.

* **Tests**
  * Tests updated to ensure description expansion occurs once before opening the transcript, verify nested renderer wrappers are bypassed when clicking native controls, and cover localized (e.g., Chinese) collapsed descriptions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/qcwssss/chatgpt-web-injector/pull/44)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->