### PR TITLE
feat: allow users to hide the text selection BOT button

### DIFF
--- a/options/options.html
+++ b/options/options.html
@@ -60,6 +60,14 @@
         </div>
       </section>
 
+      <section class="settings-section">
+        <h2>General Settings</h2>
+        <label class="checkbox-row" for="show-selection-tooltip">
+          <input id="show-selection-tooltip" type="checkbox" />
+          <span>Show floating BOT button on text selection</span>
+        </label>
+      </section>
+
       <p id="status" role="status" aria-live="polite"></p>
     </main>
 

--- a/options/options.js
+++ b/options/options.js
@@ -225,16 +225,17 @@ youtubeTemporaryChatInput.addEventListener('change', () => {
   });
 });
 
-showSelectionTooltipInput.addEventListener('change', () => {
+showSelectionTooltipInput.addEventListener('change', async () => {
   const nextChecked = showSelectionTooltipInput.checked;
 
-  saveSelectionTooltipEnabled(nextChecked).then(() => {
+  try {
+    await saveSelectionTooltipEnabled(nextChecked);
     setStatus('Settings saved.');
-  }).catch((err) => {
+  } catch (err) {
     showSelectionTooltipInput.checked = !nextChecked;
     console.error('[ChatGPT Web Injector] Tooltip preference save failed:', err);
     setStatus('Save failed. Please try again.');
-  });
+  }
 });
 
 async function init() {

--- a/options/options.js
+++ b/options/options.js
@@ -3,11 +3,13 @@ import {
   loadTemplates,
   loadYoutubeSummaryTemporaryChatEnabled,
   loadYoutubeSummaryTemplate,
+  loadSelectionTooltipEnabled,
   makeId,
   resetYoutubeSummaryTemplate,
   saveTemplates,
   saveYoutubeSummaryTemporaryChatEnabled,
   saveYoutubeSummaryTemplate,
+  saveSelectionTooltipEnabled,
 } from '../src/storage.js';
 
 const listEl = document.getElementById('template-list');
@@ -21,6 +23,7 @@ const youtubeBodyInput = document.getElementById('youtube-tpl-body');
 const youtubeTemporaryChatInput = document.getElementById('youtube-temporary-chat');
 const saveYoutubeTplBtn = document.getElementById('save-youtube-tpl');
 const resetYoutubeTplBtn = document.getElementById('reset-youtube-tpl');
+const showSelectionTooltipInput = document.getElementById('show-selection-tooltip');
 const statusEl = document.getElementById('status');
 
 let state = { templates: [], activeTemplateId: '' };
@@ -222,10 +225,23 @@ youtubeTemporaryChatInput.addEventListener('change', () => {
   });
 });
 
+showSelectionTooltipInput.addEventListener('change', () => {
+  const nextChecked = showSelectionTooltipInput.checked;
+
+  saveSelectionTooltipEnabled(nextChecked).then(() => {
+    setStatus('Settings saved.');
+  }).catch((err) => {
+    showSelectionTooltipInput.checked = !nextChecked;
+    console.error('[ChatGPT Web Injector] Tooltip preference save failed:', err);
+    setStatus('Save failed. Please try again.');
+  });
+});
+
 async function init() {
   state = await loadTemplates();
   youtubeBodyInput.value = await loadYoutubeSummaryTemplate();
   youtubeTemporaryChatInput.checked = await loadYoutubeSummaryTemporaryChatEnabled();
+  showSelectionTooltipInput.checked = await loadSelectionTooltipEnabled();
   renderList();
 
   if (window.location.hash === '#youtube-summary-template') {

--- a/src/selection_tooltip.css
+++ b/src/selection_tooltip.css
@@ -1,57 +1,41 @@
 #chatgpt-web-injector-tooltip {
   position: fixed;
   z-index: 2147483646;
-  width: 74px;
-  height: 36px;
-  border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.22);
-  background: linear-gradient(135deg, #111827 0%, #1f2937 56%, #0f766e 100%);
-  color: #ffffff;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  font-size: 12px;
-  font-weight: 650;
-  line-height: 1;
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: #1e1e1e;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 6px;
   box-shadow:
-    0 8px 24px rgba(15, 23, 42, 0.26),
-    0 2px 8px rgba(15, 23, 42, 0.18);
-  padding: 0 10px 0 8px;
+    0 8px 24px rgba(0, 0, 0, 0.4),
+    0 2px 8px rgba(0, 0, 0, 0.2);
+  padding: 0;
   transition: transform 0.12s ease, box-shadow 0.12s ease, filter 0.12s ease;
 }
 
-#chatgpt-web-injector-tooltip::before {
-  content: 'AI';
+#chatgpt-web-injector-tooltip::after {
+  content: '';
   width: 22px;
   height: 22px;
-  border-radius: 50%;
-  background: #ffffff;
-  color: #0f766e;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 9px;
-  font-weight: 800;
-  letter-spacing: 0;
-}
-
-#chatgpt-web-injector-tooltip::after {
-  content: 'Ask';
-  letter-spacing: 0;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%2310b981'%3E%3Cpath d='M11.608 2.051a.883.883 0 0 1 1.569 0l1.968 4.398c.328.733.916 1.321 1.649 1.649l4.398 1.968a.883.883 0 0 1 0 1.569l-4.398 1.968a3.176 3.176 0 0 0-1.649 1.649l-1.968 4.398a.883.883 0 0 1-1.569 0l-1.968-4.398a3.176 3.176 0 0 0-1.649-1.649l-4.398-1.968a.883.883 0 0 1 0-1.569l4.398-1.968c.733-.328 1.321-.916 1.649-1.649l1.968-4.398Z'/%3E%3C/svg%3E");
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center;
 }
 
 #chatgpt-web-injector-tooltip:hover {
-  transform: translateY(-1px) scale(1.03);
-  filter: brightness(1.06);
+  transform: translateY(-1px) scale(1.05);
+  filter: brightness(1.1);
   box-shadow:
-    0 12px 28px rgba(15, 23, 42, 0.3),
-    0 4px 12px rgba(15, 23, 42, 0.2);
+    0 12px 28px rgba(0, 0, 0, 0.5),
+    0 4px 12px rgba(0, 0, 0, 0.3);
 }
 
 #chatgpt-web-injector-tooltip:focus-visible {
-  outline: 3px solid rgba(16, 185, 129, 0.35);
+  outline: 2px solid rgba(16, 185, 129, 0.4);
   outline-offset: 2px;
 }

--- a/src/selection_tooltip.js
+++ b/src/selection_tooltip.js
@@ -13,12 +13,19 @@ let tooltipEnabled = false;
 if (chrome?.storage?.sync) {
   chrome.storage.sync.get(['showSelectionTooltip'], (data) => {
     tooltipEnabled = data.showSelectionTooltip === true;
+    if (!tooltipEnabled) {
+      clearTimeout(showTimer);
+      showTimer = null;
+      removeTooltip();
+    }
   });
 
   chrome.storage.onChanged.addListener((changes, area) => {
     if (area === 'sync' && 'showSelectionTooltip' in changes) {
       tooltipEnabled = changes.showSelectionTooltip.newValue === true;
       if (!tooltipEnabled) {
+        clearTimeout(showTimer);
+        showTimer = null;
         removeTooltip();
       }
     }
@@ -136,6 +143,8 @@ function createTooltip(x, y) {
 
 function processSelection() {
   if (!tooltipEnabled) {
+    clearTimeout(showTimer);
+    showTimer = null;
     removeTooltip();
     return;
   }

--- a/src/selection_tooltip.js
+++ b/src/selection_tooltip.js
@@ -8,6 +8,22 @@ const DEBUG = false;
 let showTimer = null;
 let lastPointerPosition = null;
 let suppressNextSelection = false;
+let tooltipEnabled = true;
+
+if (chrome?.storage?.sync) {
+  chrome.storage.sync.get(['showSelectionTooltip'], (data) => {
+    tooltipEnabled = data.showSelectionTooltip !== false;
+  });
+
+  chrome.storage.onChanged.addListener((changes, area) => {
+    if (area === 'sync' && 'showSelectionTooltip' in changes) {
+      tooltipEnabled = changes.showSelectionTooltip.newValue !== false;
+      if (!tooltipEnabled) {
+        removeTooltip();
+      }
+    }
+  });
+}
 
 function log(...args) {
   if (DEBUG) {
@@ -119,6 +135,10 @@ function createTooltip(x, y) {
 }
 
 function processSelection() {
+  if (!tooltipEnabled) {
+    removeTooltip();
+    return;
+  }
   if (suppressNextSelection) {
     suppressNextSelection = false;
     return;

--- a/src/selection_tooltip.js
+++ b/src/selection_tooltip.js
@@ -8,16 +8,16 @@ const DEBUG = false;
 let showTimer = null;
 let lastPointerPosition = null;
 let suppressNextSelection = false;
-let tooltipEnabled = true;
+let tooltipEnabled = false;
 
 if (chrome?.storage?.sync) {
   chrome.storage.sync.get(['showSelectionTooltip'], (data) => {
-    tooltipEnabled = data.showSelectionTooltip !== false;
+    tooltipEnabled = data.showSelectionTooltip === true;
   });
 
   chrome.storage.onChanged.addListener((changes, area) => {
     if (area === 'sync' && 'showSelectionTooltip' in changes) {
-      tooltipEnabled = changes.showSelectionTooltip.newValue !== false;
+      tooltipEnabled = changes.showSelectionTooltip.newValue === true;
       if (!tooltipEnabled) {
         removeTooltip();
       }

--- a/src/storage.js
+++ b/src/storage.js
@@ -132,11 +132,21 @@ export async function saveYoutubeSummaryTemporaryChatEnabled(enabled) {
 }
 
 export async function loadSelectionTooltipEnabled() {
-  const data = await chrome.storage.sync.get([SHOW_SELECTION_TOOLTIP_KEY]);
-  return data[SHOW_SELECTION_TOOLTIP_KEY] === true;
+  try {
+    const data = await chrome.storage.sync.get([SHOW_SELECTION_TOOLTIP_KEY]);
+    return data?.[SHOW_SELECTION_TOOLTIP_KEY] === true;
+  } catch (err) {
+    console.error('[ChatGPT Web Injector] Failed to load selection tooltip preference:', err);
+    return false;
+  }
 }
 
 export async function saveSelectionTooltipEnabled(enabled) {
-  await chrome.storage.sync.set({ [SHOW_SELECTION_TOOLTIP_KEY]: enabled === true });
+  try {
+    await chrome.storage.sync.set({ [SHOW_SELECTION_TOOLTIP_KEY]: enabled === true });
+  } catch (err) {
+    console.error('[ChatGPT Web Injector] Failed to save selection tooltip preference:', err);
+    throw err;
+  }
 }
 

--- a/src/storage.js
+++ b/src/storage.js
@@ -5,6 +5,7 @@ const TEMPLATES_KEY = 'templates';
 const ACTIVE_ID_KEY = 'activeTemplateId';
 const YOUTUBE_SUMMARY_TEMPLATE_KEY = 'youtubeSummaryTemplate';
 const YOUTUBE_SUMMARY_TEMPORARY_CHAT_KEY = 'youtubeSummaryTemporaryChatEnabled';
+const SHOW_SELECTION_TOOLTIP_KEY = 'showSelectionTooltip';
 
 export const DEFAULT_YOUTUBE_SUMMARY_TEMPLATE = `You are a precise video summary assistant.
 
@@ -129,3 +130,13 @@ export async function loadYoutubeSummaryTemporaryChatEnabled() {
 export async function saveYoutubeSummaryTemporaryChatEnabled(enabled) {
   await chrome.storage.sync.set({ [YOUTUBE_SUMMARY_TEMPORARY_CHAT_KEY]: enabled === true });
 }
+
+export async function loadSelectionTooltipEnabled() {
+  const data = await chrome.storage.sync.get([SHOW_SELECTION_TOOLTIP_KEY]);
+  return data[SHOW_SELECTION_TOOLTIP_KEY] !== false;
+}
+
+export async function saveSelectionTooltipEnabled(enabled) {
+  await chrome.storage.sync.set({ [SHOW_SELECTION_TOOLTIP_KEY]: enabled === true });
+}
+

--- a/src/storage.js
+++ b/src/storage.js
@@ -133,7 +133,7 @@ export async function saveYoutubeSummaryTemporaryChatEnabled(enabled) {
 
 export async function loadSelectionTooltipEnabled() {
   const data = await chrome.storage.sync.get([SHOW_SELECTION_TOOLTIP_KEY]);
-  return data[SHOW_SELECTION_TOOLTIP_KEY] !== false;
+  return data[SHOW_SELECTION_TOOLTIP_KEY] === true;
 }
 
 export async function saveSelectionTooltipEnabled(enabled) {

--- a/tests/options_html.test.js
+++ b/tests/options_html.test.js
@@ -12,3 +12,13 @@ test('Options page exposes a YouTube Temporary Chat toggle', () => {
   assert.equal(checkbox.tagName, 'INPUT');
   assert.equal(checkbox.getAttribute('type'), 'checkbox');
 });
+
+test('Options page exposes a Selection Tooltip visibility toggle', () => {
+  const html = readFileSync(new URL('../options/options.html', import.meta.url), 'utf8');
+  const dom = new JSDOM(html);
+  const checkbox = dom.window.document.getElementById('show-selection-tooltip');
+
+  assert.ok(checkbox);
+  assert.equal(checkbox.tagName, 'INPUT');
+  assert.equal(checkbox.getAttribute('type'), 'checkbox');
+});

--- a/tests/selection_tooltip.test.js
+++ b/tests/selection_tooltip.test.js
@@ -1,0 +1,105 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
+import { JSDOM } from 'jsdom';
+
+test('Selection tooltip behavior based on showSelectionTooltip preference', async () => {
+  const dom = new JSDOM('<html><body><div id="text">Hello World, this is a test text selection.</div></body></html>', {
+    url: 'https://example.com'
+  });
+
+  const store = { showSelectionTooltip: true };
+  const storageListeners = [];
+  let currentSelectionText = '';
+
+  const windowMock = new Proxy(dom.window, {
+    get(target, prop) {
+      if (prop === 'getSelection') {
+        return () => ({
+          toString() {
+            return currentSelectionText;
+          }
+        });
+      }
+      const val = target[prop];
+      if (typeof val === 'function') {
+        return val.bind(target);
+      }
+      return val;
+    }
+  });
+
+  const context = {
+    chrome: {
+      runtime: { sendMessage() {} },
+      storage: {
+        sync: {
+          get(keys, callback) {
+            const res = {};
+            for (const key of keys) {
+              res[key] = store[key];
+            }
+            if (callback) callback(res);
+            return Promise.resolve(res);
+          },
+          set(values) {
+            Object.assign(store, values);
+            return Promise.resolve();
+          }
+        },
+        onChanged: {
+          addListener(listener) {
+            storageListeners.push(listener);
+          }
+        }
+      }
+    },
+    console,
+    document: dom.window.document,
+    HTMLTextAreaElement: dom.window.HTMLTextAreaElement,
+    HTMLInputElement: dom.window.HTMLInputElement,
+    globalThis: null,
+    setTimeout(callback, delay) {
+      // 立即同步调用，消灭延迟方便测试
+      callback();
+      return 1;
+    },
+    clearTimeout() {},
+    window: windowMock,
+  };
+
+  context.globalThis = context;
+
+  // 读取并执行内容脚本
+  const source = readFileSync(new URL('../src/selection_tooltip.js', import.meta.url), 'utf8');
+  vm.runInNewContext(source, context);
+
+  // 辅助函数：触发划词事件
+  function triggerSelection(text) {
+    currentSelectionText = text;
+
+    const mouseupEvent = new dom.window.MouseEvent('mouseup', { clientX: 100, clientY: 100 });
+    dom.window.document.dispatchEvent(mouseupEvent);
+
+    const selChangeEvent = new dom.window.Event('selectionchange');
+    dom.window.document.dispatchEvent(selChangeEvent);
+  }
+
+  // 1. 默认情况下（开启），选中文本应出现悬浮按钮
+  triggerSelection('selected text');
+  let tooltipBtn = dom.window.document.getElementById('chatgpt-web-injector-tooltip');
+  assert.ok(tooltipBtn, 'Tooltip button should appear when preference is enabled');
+
+  // 2. 当在选项页关掉开关，触发 onChanged 时，已出现的按钮应当立刻被移除
+  for (const listener of storageListeners) {
+    listener({ showSelectionTooltip: { newValue: false } }, 'sync');
+  }
+  tooltipBtn = dom.window.document.getElementById('chatgpt-web-injector-tooltip');
+  assert.equal(tooltipBtn, null, 'Tooltip button should be removed instantly when preference is disabled');
+
+  // 3. 禁用情况下，选中文本不会出现悬浮按钮
+  triggerSelection('another selected text');
+  tooltipBtn = dom.window.document.getElementById('chatgpt-web-injector-tooltip');
+  assert.equal(tooltipBtn, null, 'Tooltip button should not appear when preference is disabled');
+});

--- a/tests/selection_tooltip.test.js
+++ b/tests/selection_tooltip.test.js
@@ -9,7 +9,7 @@ test('Selection tooltip behavior based on showSelectionTooltip preference', asyn
     url: 'https://example.com'
   });
 
-  const store = { showSelectionTooltip: true };
+  const store = {}; // Default is empty to test the disabled-by-default behavior
   const storageListeners = [];
   let currentSelectionText = '';
 
@@ -61,7 +61,7 @@ test('Selection tooltip behavior based on showSelectionTooltip preference', asyn
     HTMLInputElement: dom.window.HTMLInputElement,
     globalThis: null,
     setTimeout(callback, delay) {
-      // 立即同步调用，消灭延迟方便测试
+      // Execute synchronously to eliminate latency for tests
       callback();
       return 1;
     },
@@ -71,11 +71,11 @@ test('Selection tooltip behavior based on showSelectionTooltip preference', asyn
 
   context.globalThis = context;
 
-  // 读取并执行内容脚本
+  // Read and execute the content script
   const source = readFileSync(new URL('../src/selection_tooltip.js', import.meta.url), 'utf8');
   vm.runInNewContext(source, context);
 
-  // 辅助函数：触发划词事件
+  // Helper function to trigger selection events
   function triggerSelection(text) {
     currentSelectionText = text;
 
@@ -86,20 +86,28 @@ test('Selection tooltip behavior based on showSelectionTooltip preference', asyn
     dom.window.document.dispatchEvent(selChangeEvent);
   }
 
-  // 1. 默认情况下（开启），选中文本应出现悬浮按钮
+  // 1. By default (unset / no preference saved), selecting text should NOT show the tooltip button
   triggerSelection('selected text');
   let tooltipBtn = dom.window.document.getElementById('chatgpt-web-injector-tooltip');
+  assert.equal(tooltipBtn, null, 'Tooltip button should not appear by default when preference is unset');
+
+  // 2. When preference is enabled (set to true), selecting text should show the tooltip button
+  for (const listener of storageListeners) {
+    listener({ showSelectionTooltip: { newValue: true } }, 'sync');
+  }
+  triggerSelection('another selected text');
+  tooltipBtn = dom.window.document.getElementById('chatgpt-web-injector-tooltip');
   assert.ok(tooltipBtn, 'Tooltip button should appear when preference is enabled');
 
-  // 2. 当在选项页关掉开关，触发 onChanged 时，已出现的按钮应当立刻被移除
+  // 3. When preference is disabled dynamically, any existing tooltip button should be removed instantly
   for (const listener of storageListeners) {
     listener({ showSelectionTooltip: { newValue: false } }, 'sync');
   }
   tooltipBtn = dom.window.document.getElementById('chatgpt-web-injector-tooltip');
   assert.equal(tooltipBtn, null, 'Tooltip button should be removed instantly when preference is disabled');
 
-  // 3. 禁用情况下，选中文本不会出现悬浮按钮
-  triggerSelection('another selected text');
+  // 4. When preference is disabled, selecting new text should NOT show the tooltip button
+  triggerSelection('yet another selected text');
   tooltipBtn = dom.window.document.getElementById('chatgpt-web-injector-tooltip');
   assert.equal(tooltipBtn, null, 'Tooltip button should not appear when preference is disabled');
 });

--- a/tests/selection_tooltip_css.test.js
+++ b/tests/selection_tooltip_css.test.js
@@ -4,8 +4,8 @@ import { readFileSync } from 'node:fs';
 
 const tooltipCss = readFileSync(new URL('../src/selection_tooltip.css', import.meta.url), 'utf8');
 
-test('selection tooltip uses an Ask AI label instead of BOT', () => {
-  assert.match(tooltipCss, /content:\s*'AI'/);
-  assert.match(tooltipCss, /content:\s*'Ask'/);
+test('selection tooltip uses a pure SVG icon instead of text', () => {
+  assert.match(tooltipCss, /background-image:\s*url\("data:image\/svg\+xml/);
   assert.doesNotMatch(tooltipCss, /content:\s*'BOT'/);
+  assert.doesNotMatch(tooltipCss, /content:\s*'Ask'/);
 });

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -8,6 +8,8 @@ import {
   resetYoutubeSummaryTemplate,
   saveYoutubeSummaryTemporaryChatEnabled,
   saveYoutubeSummaryTemplate,
+  loadSelectionTooltipEnabled,
+  saveSelectionTooltipEnabled,
 } from '../src/storage.js';
 
 function installChromeStorage(initialData = {}) {
@@ -115,6 +117,34 @@ test('saveYoutubeSummaryTemporaryChatEnabled persists false and true values', as
     await saveYoutubeSummaryTemporaryChatEnabled(true);
     assert.equal(await loadYoutubeSummaryTemporaryChatEnabled(), true);
     assert.equal(chromeStorage.store.youtubeSummaryTemporaryChatEnabled, true);
+  } finally {
+    chromeStorage.restore();
+  }
+});
+
+test('loadSelectionTooltipEnabled defaults to true when unset', async () => {
+  const chromeStorage = installChromeStorage();
+
+  try {
+    const enabled = await loadSelectionTooltipEnabled();
+
+    assert.equal(enabled, true);
+  } finally {
+    chromeStorage.restore();
+  }
+});
+
+test('saveSelectionTooltipEnabled persists false and true values', async () => {
+  const chromeStorage = installChromeStorage();
+
+  try {
+    await saveSelectionTooltipEnabled(false);
+    assert.equal(await loadSelectionTooltipEnabled(), false);
+    assert.equal(chromeStorage.store.showSelectionTooltip, false);
+
+    await saveSelectionTooltipEnabled(true);
+    assert.equal(await loadSelectionTooltipEnabled(), true);
+    assert.equal(chromeStorage.store.showSelectionTooltip, true);
   } finally {
     chromeStorage.restore();
   }

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -122,13 +122,13 @@ test('saveYoutubeSummaryTemporaryChatEnabled persists false and true values', as
   }
 });
 
-test('loadSelectionTooltipEnabled defaults to true when unset', async () => {
+test('loadSelectionTooltipEnabled defaults to false when unset', async () => {
   const chromeStorage = installChromeStorage();
 
   try {
     const enabled = await loadSelectionTooltipEnabled();
 
-    assert.equal(enabled, true);
+    assert.equal(enabled, false);
   } finally {
     chromeStorage.restore();
   }


### PR DESCRIPTION
Closes #46. Added a setting in Options Page to toggle the visibility of the text selection BOT button and synced it in content script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "General Settings" toggle to enable/disable the floating BOT button on text selection.

* **UI/Style Updates**
  * Redesigned floating button from pill-shaped labeled control to a compact circular icon with refined hover/focus states.

* **Tests**
  * Added and updated tests covering the new toggle, storage behavior, and tooltip injection/removal based on the setting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/qcwssss/chatgpt-web-injector/pull/48?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->