### PR TITLE
fix: prevent misclicking transcript segments during close button search

### DIFF
--- a/src/youtube_summary.js
+++ b/src/youtube_summary.js
@@ -391,20 +391,24 @@ function findTranscriptCloseButton(panel = findTranscriptPanel()) {
   ].join(', ')));
 
   return buttons.find((button) => {
+    // Skip our injected buttons, hidden elements, and buttons inside transcript segments.
+    // Also guard against long text containing 'close' (e.g. 'closed models') matching incorrectly.
     if (
       button.id === YOUTUBE_SUMMARY_BUTTON_ID ||
       button.id === YOUTUBE_TRANSCRIPT_BUTTON_ID ||
+      button.closest(TRANSCRIPT_SEGMENT_SELECTOR) ||
       !isElementVisible(button)
     ) {
       return false;
     }
 
+    const textContent = (button.textContent || '').trim();
     const label = [
       button.id || '',
       button.className || '',
       button.getAttribute('aria-label') || '',
       button.getAttribute('title') || '',
-      button.textContent || '',
+      textContent.length <= 15 ? textContent : '',
     ].join(' ');
     return closePattern.test(label);
   }) || null;

--- a/tests/youtube_summary.test.js
+++ b/tests/youtube_summary.test.js
@@ -592,3 +592,43 @@ test('loadYoutubeSummary restores chrome when script loading fails', () => {
 
   dom.window.eval = previousEval;
 });
+
+test('YouTube transcript panel button closes an open transcript panel and ignores transcript segments containing close keywords like closed', async () => {
+  const dom = new JSDOM(`
+    <html>
+      <body>
+        <div class="ytp-chrome-controls">
+          <button class="ytp-subtitles-button" aria-pressed="false">CC</button>
+        </div>
+        <ytd-engagement-panel-section-list-renderer visibility="ENGAGEMENT_PANEL_VISIBILITY_EXPANDED">
+          <button aria-label="Close transcript">Close</button>
+          <ytd-transcript-segment-renderer>
+            <button class="segment-text">we have open weight models that are approaching closed models</button>
+          </ytd-transcript-segment-renderer>
+        </ytd-engagement-panel-section-list-renderer>
+      </body>
+    </html>
+  `, {
+    runScripts: 'outside-only',
+    url: 'https://www.youtube.com/watch?v=test123',
+  });
+
+  let closeClicked = false;
+  let segmentClicked = false;
+
+  dom.window.document.querySelector('[aria-label="Close transcript"]').addEventListener('click', () => {
+    closeClicked = true;
+  });
+  dom.window.document.querySelector('.segment-text').addEventListener('click', () => {
+    segmentClicked = true;
+  });
+
+  loadYoutubeSummary(dom);
+
+  const button = dom.window.document.getElementById('chatgpt-web-injector-youtube-transcript');
+  button.click();
+  await Promise.resolve();
+
+  assert.equal(closeClicked, true, 'The close button should be clicked');
+  assert.equal(segmentClicked, false, 'The transcript segment containing closed should NOT be clicked');
+});


### PR DESCRIPTION
This PR resolves the issue where the injected YouTube Transcript toggle button misclicks a transcript segment containing closed-caption words (e.g. 'closed') or long paragraphs instead of closing the panel.

### Root Cause
In `youtube_summary.js`, `findTranscriptCloseButton` matched all buttons inside the panel by regex `/close|dismiss|关闭|關閉/i` against their concatenated attributes + `textContent`. If any visible subtitle line (which is also clickable) contains words like "closed", it would erroneously match it as the close button.

### Fix
1. Explicitly filter out buttons/elements residing inside `TRANSCRIPT_SEGMENT_SELECTOR` (i.e. subtitle items) in `findTranscriptCloseButton`.
2. Restrict the matching of `textContent` to a maximum length of 15 characters to prevent matching long paragraphs containing the keyword.
3. Added a detailed unit test to guarantee this behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the transcript panel close button detection to be more selective and reliable, preventing false matches from unrelated transcript segments and extension-injected elements during panel closure.

* **Tests**
  * Added test coverage to verify that the transcript panel close functionality works correctly without accidentally activating transcript segments containing similar keywords.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/qcwssss/chatgpt-web-injector/pull/49?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->