### PR TITLE
fix: expand close button search to outermost engagement panel

### DIFF
--- a/src/youtube_summary.js
+++ b/src/youtube_summary.js
@@ -467,7 +467,11 @@ async function fetchTranscriptFromDom() {
 async function toggleTranscriptPanel() {
   const panel = findTranscriptPanel();
   if (panel) {
-    const closeButton = findTranscriptCloseButton(panel);
+    // findTranscriptPanel() may return an inner element (e.g. ytd-transcript-renderer)
+    // whose scope does not include the close button. Expand to the outermost engagement
+    // panel so the close button is always within the search range.
+    const outerPanel = panel.closest('ytd-engagement-panel-section-list-renderer') || panel;
+    const closeButton = findTranscriptCloseButton(outerPanel);
     if (!closeButton) {
       showStatus('Transcript unavailable');
       return;

--- a/tests/youtube_summary.test.js
+++ b/tests/youtube_summary.test.js
@@ -235,6 +235,47 @@ test('YouTube transcript panel button closes an open transcript panel', async ()
   assert.equal(dom.window.document.getElementById('chatgpt-web-injector-youtube-status'), null);
 });
 
+test('YouTube transcript panel button closes panel when ytd-transcript-renderer wraps segments', async () => {
+  // Mirrors real YouTube DOM where ytd-transcript-renderer is an intermediate
+  // layer between the engagement panel and transcript segments. The close button
+  // sits outside this inner renderer, so the search must expand to the outer panel.
+  const dom = new JSDOM(`
+    <html>
+      <body>
+        <div class="ytp-chrome-controls">
+          <button class="ytp-subtitles-button" aria-pressed="false">CC</button>
+        </div>
+        <ytd-engagement-panel-section-list-renderer>
+          <button aria-label="Close">Close</button>
+          <ytd-transcript-renderer>
+            <ytd-transcript-segment-renderer>
+              <span class="segment-timestamp">0:05</span>
+              <span class="segment-text">Hello world</span>
+            </ytd-transcript-segment-renderer>
+          </ytd-transcript-renderer>
+        </ytd-engagement-panel-section-list-renderer>
+      </body>
+    </html>
+  `, {
+    runScripts: 'outside-only',
+    url: 'https://www.youtube.com/watch?v=test123',
+  });
+
+  let closeClicked = false;
+  dom.window.document.querySelector('[aria-label="Close"]').addEventListener('click', () => {
+    closeClicked = true;
+  });
+
+  loadYoutubeSummary(dom);
+
+  const button = dom.window.document.getElementById('chatgpt-web-injector-youtube-transcript');
+  button.click();
+  await Promise.resolve();
+
+  assert.equal(closeClicked, true, 'Close button outside ytd-transcript-renderer should be found and clicked');
+  assert.equal(dom.window.document.getElementById('chatgpt-web-injector-youtube-status'), null);
+});
+
 test('YouTube transcript panel button closes an open transcript panel with an unlabeled dismiss button', async () => {
   const dom = new JSDOM(`
     <html>


### PR DESCRIPTION
Fixes the issue where clicking the Transcript button shows 'Transcript unavailable' instead of closing the panel on certain YouTube videos.

### Root Cause
`findTranscriptPanel()` uses `segment.closest()` which may return an inner element (`ytd-transcript-renderer`) instead of the outermost `ytd-engagement-panel-section-list-renderer`. The close button sits outside this inner element, so `findTranscriptCloseButton()` could not find it.

This only affects videos where YouTube wraps transcript segments inside `ytd-transcript-renderer` (older DOM structure). Videos using the newer `transcript-segment-view-model` structure without this wrapper were unaffected.

### Fix
In `toggleTranscriptPanel()`, expand the panel reference to the outermost `ytd-engagement-panel-section-list-renderer` before searching for the close button.

### Testing
- Added a test case mirroring the real nested DOM structure
- All 59 tests pass