### PR TITLE
feat: options page visual layout refresh and YouTube summary prioritize

### DIFF
--- a/options/options.css
+++ b/options/options.css
@@ -30,8 +30,20 @@ h2 {
   color: #4b5563;
 }
 
+.section-subtitle {
+  font-size: 0.8rem;
+  color: #64748b;
+  margin: 4px 0 0;
+  font-weight: 400;
+}
+
 .settings-section {
-  margin-bottom: 28px;
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 24px;
+  margin-bottom: 24px;
+  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.05), 0 1px 2px -1px rgba(0, 0, 0, 0.05);
 }
 
 /* ---- Template list ---- */
@@ -110,16 +122,103 @@ label:first-child {
   margin-top: 0;
 }
 
-.checkbox-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
+/* ---- Modern Settings Card & Group Layout ---- */
+.setting-card {
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  background: #f8fafc;
   margin-top: 14px;
+  overflow: hidden;
 }
 
-.checkbox-row input {
-  width: 16px;
-  height: 16px;
+.setting-card-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px;
+  gap: 20px;
+}
+
+.setting-item-meta {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.setting-icon {
+  width: 20px;
+  height: 20px;
+  color: #64748b;
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.setting-details {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.setting-title {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: #1e293b;
+}
+
+.setting-description {
+  font-size: 0.825rem;
+  color: #64748b;
+  line-height: 1.4;
+}
+
+/* ---- Modern Toggle Switch ---- */
+.toggle-switch {
+  position: relative;
+  display: inline-block;
+  width: 36px;
+  height: 20px;
+  flex-shrink: 0;
+}
+
+.toggle-switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #cbd5e1;
+  border-radius: 20px;
+}
+
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 14px;
+  width: 14px;
+  left: 3px;
+  bottom: 3px;
+  background-color: white;
+  border-radius: 50%;
+}
+
+.toggle-switch input:checked + .slider {
+  background-color: #0070f3;
+}
+
+.toggle-switch input:checked + .slider:before {
+  transform: translateX(16px);
+}
+
+/* 无障碍键盘 Tab 聚焦焦点发光环 */
+.toggle-switch input:focus-visible + .slider {
+  box-shadow: 0 0 0 2px rgba(0, 112, 243, 0.4);
 }
 
 input[type='text'] {

--- a/options/options.html
+++ b/options/options.html
@@ -9,11 +9,55 @@
   <body>
     <main class="container">
       <h1>ChatGPT Web Injector</h1>
-      <p class="subtitle">Manage your prompt templates. The active template is used by the floating button and as the default send action.</p>
+      <p class="subtitle">Customize your prompt templates and behavior below.</p>
 
+      <!-- Section 1: YouTube Summary Template (置顶) -->
+      <section id="youtube-summary-template" class="settings-section">
+        <div class="templates-header">
+          <div>
+            <h2>YouTube Summary Template</h2>
+            <p class="section-subtitle">Dedicated template used automatically when you click the 'Transcribe' button on YouTube.</p>
+          </div>
+          <button id="reset-youtube-tpl" type="button" class="btn-secondary">Reset</button>
+        </div>
+
+        <label for="youtube-tpl-body">Prompt template</label>
+        <textarea id="youtube-tpl-body" rows="12" spellcheck="false"></textarea>
+
+        <p class="variables">
+          Available variables: <code>{{title}}</code>, <code>{{url}}</code>, <code>{{transcript}}</code>
+        </p>
+
+        <div class="setting-card">
+          <div class="setting-card-item">
+            <div class="setting-item-meta">
+              <svg class="setting-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"/>
+              </svg>
+              <div class="setting-details">
+                <span id="temp-chat-title" class="setting-title">Use Temporary Chat for YouTube summaries</span>
+                <span class="setting-description">Use a transient conversation session. Messages won't be saved in your ChatGPT sidebar history.</span>
+              </div>
+            </div>
+            <label class="toggle-switch">
+              <input id="youtube-temporary-chat" type="checkbox" aria-labelledby="temp-chat-title" />
+              <span class="slider"></span>
+            </label>
+          </div>
+        </div>
+
+        <div class="actions">
+          <button id="save-youtube-tpl" type="button">Save YouTube template</button>
+        </div>
+      </section>
+
+      <!-- Section 2: Web Selection Templates -->
       <section class="settings-section">
         <div class="templates-header">
-          <h2>Templates</h2>
+          <div>
+            <h2>Web Selection Templates</h2>
+            <p class="section-subtitle">Templates used for selected webpage text via the floating BOT button or context menu.</p>
+          </div>
           <button id="add-template" type="button" class="btn-secondary">+ New template</button>
         </div>
 
@@ -37,35 +81,29 @@
         </div>
       </section>
 
-      <section id="youtube-summary-template" class="settings-section">
-        <div class="templates-header">
-          <h2>YouTube Summary Template</h2>
-          <button id="reset-youtube-tpl" type="button" class="btn-secondary">Reset</button>
-        </div>
-
-        <label for="youtube-tpl-body">Prompt template</label>
-        <textarea id="youtube-tpl-body" rows="12" spellcheck="false"></textarea>
-
-        <p class="variables">
-          Available variables: <code>{{title}}</code>, <code>{{url}}</code>, <code>{{transcript}}</code>
-        </p>
-
-        <label class="checkbox-row" for="youtube-temporary-chat">
-          <input id="youtube-temporary-chat" type="checkbox" />
-          <span>Use Temporary Chat for YouTube summaries</span>
-        </label>
-
-        <div class="actions">
-          <button id="save-youtube-tpl" type="button">Save YouTube template</button>
-        </div>
-      </section>
-
+      <!-- Section 3: General Settings -->
       <section class="settings-section">
         <h2>General Settings</h2>
-        <label class="checkbox-row" for="show-selection-tooltip">
-          <input id="show-selection-tooltip" type="checkbox" />
-          <span>Show floating BOT button on text selection</span>
-        </label>
+        <div class="setting-card">
+          <div class="setting-card-item">
+            <div class="setting-item-meta">
+              <svg class="setting-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
+                <line x1="9" y1="9" x2="15" y2="9"/>
+                <line x1="9" y1="13" x2="15" y2="13"/>
+                <line x1="9" y1="17" x2="11" y2="17"/>
+              </svg>
+              <div class="setting-details">
+                <span id="tooltip-title" class="setting-title">Show floating BOT button on text selection</span>
+                <span class="setting-description">Display a quick trigger icon near your cursor when selecting text on any web page.</span>
+              </div>
+            </div>
+            <label class="toggle-switch">
+              <input id="show-selection-tooltip" type="checkbox" aria-labelledby="tooltip-title" />
+              <span class="slider"></span>
+            </label>
+          </div>
+        </div>
       </section>
 
       <p id="status" role="status" aria-live="polite"></p>


### PR DESCRIPTION
## Summary
This PR refactors the visual design and layout flow of the extension's options page. It prioritizes the core feature—YouTube Summary Template—by moving it to the very top. It also clarifies the confusing "Templates" naming by renaming general templates to "Web Selection Templates" with contextual subtitles. 

## Changes
- **options/options.html**: Swapped card sections so "YouTube Summary Template" sits at the top. Renamed general templates to "Web Selection Templates". Added descriptive section subtitles.
- **options/options.css**: Implemented elegant cards with rounded corners (12px), subtle shadows, custom HSL toggle switches, focus-visible outlines, and beautiful section typography.
