### PR TITLE
feat: translate YouTube download button labels to English

### DIFF
--- a/src/youtube_summary.js
+++ b/src/youtube_summary.js
@@ -828,7 +828,7 @@ async function toggleDownloadMenu(button) {
         transition: all 0.15s ease;
       ">
         <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" style="margin-right: 6px; vertical-align: middle;"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
-        SRT 字幕格式下载
+        Download SRT
       </button>
       <button type="button" class="youtube-download-large-btn txt-btn" data-type="txt" style="
         display: flex;
@@ -846,7 +846,7 @@ async function toggleDownloadMenu(button) {
         transition: all 0.15s ease;
       ">
         <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" style="margin-right: 6px; vertical-align: middle;"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
-        TXT 纯文本格式下载
+        Download TXT
       </button>
     </div>
   `;


### PR DESCRIPTION
This PR translates the YouTube download popover buttons from Chinese to English ('Download SRT' and 'Download TXT') to keep the plugin UI consistently in English.