### PR TITLE
feat: merge redundant settings buttons in popup into a single configure link

### DIFF
--- a/popup/popup.css
+++ b/popup/popup.css
@@ -6,80 +6,96 @@
   padding: 0;
 }
 
+/* 消除外层 HTML 的一切间距，背景透明 */
+html {
+  margin: 0;
+  padding: 0;
+  background: transparent;
+}
+
+/* 黄金法门：将 12px 平滑大圆角与裁切直接施加于 body 容器上，并且绝对不能留有任何 margin/padding */
 body {
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   font-size: 13.5px;
-  color: #1e293b; /* 更加高级的深邃灰蓝，代替纯黑 */
-  background: #ffffff;
+  color: #1e293b;
+  background: #ffffff; /* 必须给 body 纯白背景以阻止 Chrome 渲染底座露出 */
+  margin: 0;
+  padding: 0;
+  border-radius: 12px; /* 优雅的 12px 苹果风圆角 */
+  overflow: hidden; /* 强制对 body 进行溢出裁剪，彻底根除任何外部冷硬直角框 */
   min-width: 240px;
   max-width: 320px;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
+/* 内部容器：100% 占满 body，不需要任何外边距或内边距缩进 */
 .container {
+  background: #ffffff;
   padding: 14px 0 0;
+  display: flex;
+  flex-direction: column;
 }
 
+/* 顶部标题区 */
 h1 {
   font-size: 11px;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: #64748b; /* 优雅的冷灰，更具现代极简风 */
+  color: #64748b;
   padding: 0 16px 10px;
-  border-bottom: 1px solid #f1f5f9; /* 更加细腻微弱的分割线 */
+  border-bottom: 1px solid rgba(0, 0, 0, 0.03); /* 高雅极淡的分割线 */
 }
 
+/* 列表区 */
 .template-list {
   list-style: none;
   max-height: 280px;
   overflow-y: auto;
-  padding: 6px 0; /* 留出精致的上下间距 */
+  padding: 6px 0;
 }
 
-/* 隐藏滚动条背景，保持苹果级别的干净滑轨 */
+/* 精细圆角隐藏滑轨 */
 .template-list::-webkit-scrollbar {
   width: 4px;
 }
 
 .template-list::-webkit-scrollbar-thumb {
-  background: #cbd5e1;
-  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.1);
+  border-radius: 10px;
 }
 
-/* 将传统的列表项重构为现代悬浮气泡卡片 (Bubble Cards) */
+/* 精致气泡卡片 (10px 圆角) */
 .template-item {
   display: flex;
   align-items: center;
   gap: 10px;
-  margin: 3px 8px; /* 产生卡片悬浮间距，不再是死板的整行色块 */
+  margin: 3px 10px;
   padding: 8px 12px;
   cursor: pointer;
-  border-radius: 8px; /* 优雅圆角 */
+  border-radius: 10px; /* 超高亲和力的平滑小圆角 */
   border: 1px solid transparent;
-  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1); /* 高级缓动过渡 */
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
   user-select: none;
 }
 
-/* 精致的卡片 Hover 微影反馈 */
 .template-item:hover {
   background: #f8fafc;
   border-color: #e2e8f0;
   transform: translateY(-0.5px);
 }
 
-/* 激活状态：采用高保真极简微蓝渐变与微妙阴影 */
+/* 激活状态 */
 .template-item.is-active {
-  background: rgba(0, 102, 255, 0.05); /* 精致透亮的科技蓝微光背景 */
-  border-color: rgba(0, 102, 255, 0.15);
+  background: rgba(0, 102, 255, 0.04);
+  border-color: rgba(0, 102, 255, 0.12);
 }
 
 .template-item.is-active:hover {
-  background: rgba(0, 102, 255, 0.08);
+  background: rgba(0, 102, 255, 0.06);
 }
 
-/* 极简蓝勾 Checkmark */
 .template-item__check {
   width: 14px;
   height: 14px;
@@ -94,7 +110,7 @@ h1 {
 }
 
 .template-item.is-active .template-item__check {
-  transform: scale(1.1);
+  transform: scale(1.05);
 }
 
 .template-item__name {
@@ -109,13 +125,13 @@ h1 {
 
 .template-item.is-active .template-item__name {
   font-weight: 600;
-  color: #0066ff; /* 激活项字体颜色优雅转蓝 */
+  color: #0066ff;
 }
 
-/* 选项栏目 */
+/* 快捷设置区域 */
 .settings-section {
-  border-top: 1px solid #f1f5f9;
-  background: #f8fafc; /* 高级亮灰色背景，提供层次感分割 */
+  border-top: 1px solid rgba(0, 0, 0, 0.03);
+  background: #fafafa;
   padding: 2px 0;
 }
 
@@ -133,7 +149,7 @@ h1 {
   letter-spacing: 0.01em;
 }
 
-/* 开关控件高保真优化 */
+/* 胶囊开关控件 (Rounded Switch) */
 .switch {
   position: relative;
   display: inline-block;
@@ -169,30 +185,30 @@ h1 {
   bottom: 3px;
   background-color: #ffffff;
   border-radius: 50%;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15); /* 给滑块加入优雅轻影 */
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
   transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .switch input:checked + .slider {
-  background-color: #0066ff; /* 激活使用高饱和科技蓝 */
+  background-color: #0066ff;
 }
 
 .switch input:checked + .slider:before {
   transform: translateX(16px);
 }
 
-/* 智能聚焦边缘光晕，极度符合 Accessibility 指导规范 */
 .switch input:focus-visible + .slider {
   box-shadow: 0 0 0 2px rgba(0, 102, 255, 0.3);
 }
 
-/* 底部区域设计 */
+/* 底部操作区：去除生硬粗线，代以极柔化微淡分割 */
 .footer {
-  border-top: 1px solid #f1f5f9;
+  border-top: 1px solid rgba(0, 0, 0, 0.03);
   padding: 10px 16px;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
+  background: #ffffff;
 }
 
 .manage-link {
@@ -210,7 +226,6 @@ h1 {
   transition: color 0.15s ease;
 }
 
-/* 右侧加入微小指示箭头动效，增加 SaaS 高级指引感 */
 .manage-link::after {
   content: "→";
   font-size: 12px;
@@ -222,5 +237,5 @@ h1 {
 }
 
 .manage-link:hover::after {
-  transform: translateX(2px); /* 悬浮时箭头向右微动，带来绝佳的微交互反馈 */
+  transform: translateX(2px);
 }

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -7,63 +7,94 @@
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  font-size: 14px;
-  color: #1a1a1a;
-  background: #fff;
-  min-width: 220px;
-  max-width: 300px;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-size: 13.5px;
+  color: #1e293b; /* 更加高级的深邃灰蓝，代替纯黑 */
+  background: #ffffff;
+  min-width: 240px;
+  max-width: 320px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 .container {
-  padding: 12px 0 0;
+  padding: 14px 0 0;
 }
 
 h1 {
-  font-size: 12px;
-  font-weight: 600;
+  font-size: 11px;
+  font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: #888;
-  padding: 0 14px 8px;
-  border-bottom: 1px solid #f0f0f0;
+  letter-spacing: 0.08em;
+  color: #64748b; /* 优雅的冷灰，更具现代极简风 */
+  padding: 0 16px 10px;
+  border-bottom: 1px solid #f1f5f9; /* 更加细腻微弱的分割线 */
 }
 
 .template-list {
   list-style: none;
-  max-height: 320px;
+  max-height: 280px;
   overflow-y: auto;
+  padding: 6px 0; /* 留出精致的上下间距 */
 }
 
+/* 隐藏滚动条背景，保持苹果级别的干净滑轨 */
+.template-list::-webkit-scrollbar {
+  width: 4px;
+}
+
+.template-list::-webkit-scrollbar-thumb {
+  background: #cbd5e1;
+  border-radius: 4px;
+}
+
+/* 将传统的列表项重构为现代悬浮气泡卡片 (Bubble Cards) */
 .template-item {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 9px 14px;
+  gap: 10px;
+  margin: 3px 8px; /* 产生卡片悬浮间距，不再是死板的整行色块 */
+  padding: 8px 12px;
   cursor: pointer;
-  border-radius: 0;
-  transition: background 0.1s;
+  border-radius: 8px; /* 优雅圆角 */
+  border: 1px solid transparent;
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1); /* 高级缓动过渡 */
   user-select: none;
 }
 
+/* 精致的卡片 Hover 微影反馈 */
 .template-item:hover {
-  background: #f5f5f5;
+  background: #f8fafc;
+  border-color: #e2e8f0;
+  transform: translateY(-0.5px);
 }
 
+/* 激活状态：采用高保真极简微蓝渐变与微妙阴影 */
 .template-item.is-active {
-  background: #f0f7ff;
+  background: rgba(0, 102, 255, 0.05); /* 精致透亮的科技蓝微光背景 */
+  border-color: rgba(0, 102, 255, 0.15);
 }
 
 .template-item.is-active:hover {
-  background: #e5f0ff;
+  background: rgba(0, 102, 255, 0.08);
 }
 
+/* 极简蓝勾 Checkmark */
 .template-item__check {
-  width: 16px;
-  font-size: 13px;
-  color: #0070f3;
+  width: 14px;
+  height: 14px;
+  font-size: 12px;
+  font-weight: bold;
+  color: #0066ff;
   flex-shrink: 0;
-  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.2s ease;
+}
+
+.template-item.is-active .template-item__check {
+  transform: scale(1.1);
 }
 
 .template-item__name {
@@ -71,74 +102,52 @@ h1 {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  font-weight: 500;
+  color: #475569;
+  transition: color 0.15s ease;
 }
 
 .template-item.is-active .template-item__name {
   font-weight: 600;
-  color: #0070f3;
+  color: #0066ff; /* 激活项字体颜色优雅转蓝 */
 }
 
-.footer {
-  border-top: 1px solid #f0f0f0;
-  padding: 8px 14px;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 7px;
-}
-
-.manage-link {
-  background: none;
-  border: none;
-  cursor: pointer;
-  font-size: 12px;
-  color: #888;
-  padding: 0;
-  text-decoration: none;
-  transition: color 0.1s;
-}
-
-.manage-link:hover {
-  color: #1a1a1a;
-  text-decoration: underline;
-}
-
+/* 选项栏目 */
 .settings-section {
-  border-top: 1px solid #f0f0f0;
-  background: #fafafa;
-  padding: 4px 0;
+  border-top: 1px solid #f1f5f9;
+  background: #f8fafc; /* 高级亮灰色背景，提供层次感分割 */
+  padding: 2px 0;
 }
 
 .setting-row {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 8px 14px;
+  padding: 10px 16px;
 }
 
 .setting-text {
-  font-size: 12px;
-  color: #555;
-  font-weight: 500;
+  font-size: 11.5px;
+  color: #475569;
+  font-weight: 600;
+  letter-spacing: 0.01em;
 }
 
-/* Switch 开关容器 */
+/* 开关控件高保真优化 */
 .switch {
   position: relative;
   display: inline-block;
-  width: 32px;
+  width: 34px;
   height: 18px;
   flex-shrink: 0;
 }
 
-/* 隐藏隐藏底层的 checkbox */
 .switch input {
   opacity: 0;
   width: 0;
   height: 0;
 }
 
-/* 开关滑槽 */
 .slider {
   position: absolute;
   cursor: pointer;
@@ -146,11 +155,11 @@ h1 {
   left: 0;
   right: 0;
   bottom: 0;
-  background-color: #ccc;
+  background-color: #cbd5e1;
   border-radius: 18px;
+  transition: background-color 0.25s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-/* 开关圆形按钮 */
 .slider:before {
   position: absolute;
   content: "";
@@ -158,22 +167,60 @@ h1 {
   width: 12px;
   left: 3px;
   bottom: 3px;
-  background-color: white;
+  background-color: #ffffff;
   border-radius: 50%;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15); /* 给滑块加入优雅轻影 */
+  transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-/* 激活状态滑槽背景色 */
 .switch input:checked + .slider {
-  background-color: #0070f3;
+  background-color: #0066ff; /* 激活使用高饱和科技蓝 */
 }
 
-/* 激活状态按钮水平移动 */
 .switch input:checked + .slider:before {
-  transform: translateX(14px);
+  transform: translateX(16px);
 }
 
-/* 键盘聚焦状态下的自定义焦点指示器 */
+/* 智能聚焦边缘光晕，极度符合 Accessibility 指导规范 */
 .switch input:focus-visible + .slider {
-  box-shadow: 0 0 0 2px rgba(0, 112, 243, 0.4);
+  box-shadow: 0 0 0 2px rgba(0, 102, 255, 0.3);
 }
 
+/* 底部区域设计 */
+.footer {
+  border-top: 1px solid #f1f5f9;
+  padding: 10px 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.manage-link {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 11.5px;
+  font-weight: 600;
+  color: #64748b;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  text-decoration: none;
+  transition: color 0.15s ease;
+}
+
+/* 右侧加入微小指示箭头动效，增加 SaaS 高级指引感 */
+.manage-link::after {
+  content: "→";
+  font-size: 12px;
+  transition: transform 0.15s ease;
+}
+
+.manage-link:hover {
+  color: #0066ff;
+}
+
+.manage-link:hover::after {
+  transform: translateX(2px); /* 悬浮时箭头向右微动，带来绝佳的微交互反馈 */
+}

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -20,8 +20,7 @@
         </div>
       </div>
       <div class="footer">
-        <button id="manage-btn" type="button" class="manage-link">Manage templates</button>
-        <button id="youtube-template-btn" type="button" class="manage-link">Edit YouTube summary</button>
+        <button id="manage-btn" type="button" class="manage-link">Configure templates</button>
       </div>
     </div>
     <script type="module" src="./popup.js"></script>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -7,7 +7,6 @@ import {
 
 const listEl = document.getElementById('template-list');
 const manageBtn = document.getElementById('manage-btn');
-const youtubeTemplateBtn = document.getElementById('youtube-template-btn');
 
 let state = { templates: [], activeTemplateId: '' };
 
@@ -85,11 +84,6 @@ listEl.addEventListener('keydown', (e) => {
 
 manageBtn.addEventListener('click', () => {
   chrome.tabs.create({ url: chrome.runtime.getURL('options/options.html') });
-  window.close();
-});
-
-youtubeTemplateBtn.addEventListener('click', () => {
-  chrome.tabs.create({ url: chrome.runtime.getURL('options/options.html#youtube-summary-template') });
   window.close();
 });
 


### PR DESCRIPTION
This PR merges the redundant 'Manage templates' and 'Edit YouTube summary' buttons in the extension popup into a single, clean 'Configure templates' button to improve user experience.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Updated "Manage templates" button label to "Configure templates."
  * Removed YouTube template quick-access button from popup interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/qcwssss/chatgpt-web-injector/pull/59?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->