### PR TITLE
feat(popup): add option to toggle floating bot button in popup

### DIFF
--- a/popup/popup.html
+++ b/popup/popup.html
@@ -18,6 +18,13 @@
             <span class="slider"></span>
           </label>
         </div>
+        <div class="setting-row">
+          <span id="tooltip-toggle-label" class="setting-text">Show floating BOT button</span>
+          <label class="switch">
+            <input type="checkbox" id="floating-bot-toggle" aria-labelledby="tooltip-toggle-label">
+            <span class="slider"></span>
+          </label>
+        </div>
       </div>
       <div class="footer">
         <button id="manage-btn" type="button" class="manage-link">Configure templates</button>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -2,7 +2,9 @@ import {
   loadTemplates,
   saveTemplates,
   loadYoutubeSummaryTemporaryChatEnabled,
-  saveYoutubeSummaryTemporaryChatEnabled
+  saveYoutubeSummaryTemporaryChatEnabled,
+  loadSelectionTooltipEnabled,
+  saveSelectionTooltipEnabled
 } from '../src/storage.js';
 
 const listEl = document.getElementById('template-list');
@@ -88,6 +90,7 @@ manageBtn.addEventListener('click', () => {
 });
 
 const tempChatToggle = document.getElementById('youtube-temp-chat-toggle');
+const tooltipToggle = document.getElementById('floating-bot-toggle');
 
 async function init() {
   state = await loadTemplates();
@@ -102,12 +105,32 @@ async function init() {
     console.error('[ChatGPT Web Injector] Failed to load youtube summary temporary chat state:', err);
   }
 
+  try {
+    const tooltipEnabled = await loadSelectionTooltipEnabled();
+    if (tooltipToggle) {
+      tooltipToggle.checked = tooltipEnabled;
+    }
+  } catch (err) {
+    console.error('[ChatGPT Web Injector] Failed to load tooltip enabled state:', err);
+  }
+
   if (tempChatToggle) {
     tempChatToggle.addEventListener('change', async (e) => {
       try {
         await saveYoutubeSummaryTemporaryChatEnabled(e.target.checked);
       } catch (err) {
         console.error('[ChatGPT Web Injector] Failed to save youtube summary temporary chat state:', err);
+        e.target.checked = !e.target.checked;
+      }
+    });
+  }
+
+  if (tooltipToggle) {
+    tooltipToggle.addEventListener('change', async (e) => {
+      try {
+        await saveSelectionTooltipEnabled(e.target.checked);
+      } catch (err) {
+        console.error('[ChatGPT Web Injector] Failed to save tooltip enabled state:', err);
         e.target.checked = !e.target.checked;
       }
     });


### PR DESCRIPTION
This PR adds the 'Show floating BOT button' setting toggle directly to the extension's popup UI (under 'Use Temporary Chat'). This allows users to toggle the floating BOT button on text selection without navigating to the Options page.

## Changes
- **popup/popup.html**: Added the HTML switch row.
- **popup/popup.js**: Loaded and saved the showSelectionTooltip preference.

## Tests
- All automated tests pass (npm test).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added a "Show floating BOT button" toggle setting in the popup interface to control the floating bot button visibility
* Toggle state is automatically saved and persists across sessions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->