### PR TITLE
fix(youtube): hide summary buttons when video has no captions

### DIFF
--- a/src/youtube_summary.js
+++ b/src/youtube_summary.js
@@ -26,6 +26,7 @@ let observerTimer = null;
 let observerRetryTimer = null;
 let latestCaptionCheckId = 0;
 const noCaptionUrls = new Set();
+const NO_CAPTION_CACHE_LIMIT = 100;
 
 function log(...args) {
   if (DEBUG) {
@@ -558,15 +559,21 @@ function getCaptionTracks(playerResponse) {
 
 /**
  * 轮询等待 playerResponse 中的 captionTracks 数据，最多等待 TRANSCRIPT_DOM_WAIT_MS 毫秒。
+ * @param {string} videoId - 当前视频的 ID，用于校验 playerResponse 是否匹配当前视频
  * 返回 true 表示视频有可用字幕；返回 false 表示无字幕（直播/无字幕视频）。
  */
-async function hasCaptionTracks() {
+async function hasCaptionTracks(videoId) {
   const startedAt = Date.now();
 
   while (Date.now() - startedAt < TRANSCRIPT_DOM_WAIT_MS) {
+    // SPA 路由切换时提前终止轮询，避免无效 CPU 消耗
+    const currentVideoId = new URLSearchParams(window.location.search).get('v');
+    if (videoId !== currentVideoId) {
+      return false;
+    }
     const playerResponse = getPlayerResponseFromPageScripts();
-    if (playerResponse) {
-      // playerResponse 已解析，直接判断 captionTracks
+    // 校验 playerResponse 的 videoId 是否匹配，避免读到上一个视频的过期数据
+    if (playerResponse && playerResponse.videoDetails?.videoId === videoId) {
       return getCaptionTracks(playerResponse).length > 0;
     }
     await new Promise((resolve) => { setTimeout(resolve, TRANSCRIPT_DOM_POLL_MS); });
@@ -989,14 +996,20 @@ function mountButton() {
   // 挂载后异步检测字幕可用性：若该视频无字幕轨道则移除按钮，避免误导用户
   const captionCheckId = ++latestCaptionCheckId;
   const mountUrl = window.location.href;
+  const currentVideoId = new URLSearchParams(window.location.search).get('v');
   (async () => {
     try {
-      const captionsAvailable = await hasCaptionTracks();
+      const captionsAvailable = await hasCaptionTracks(currentVideoId);
       // 竞态保护：若检测期间已切换视频或触发了新一轮挂载，则丢弃过期结果
       if (captionCheckId !== latestCaptionCheckId) return;
       if (mountUrl !== window.location.href) return;
       if (!captionsAvailable) {
         log('该视频没有可用的字幕轨道，移除已挂载的功能按钮。');
+        // FIFO 策略限制缓存大小，防止 SPA 长时间使用导致内存泄漏
+        if (noCaptionUrls.size >= NO_CAPTION_CACHE_LIMIT) {
+          const oldest = noCaptionUrls.values().next().value;
+          noCaptionUrls.delete(oldest);
+        }
         noCaptionUrls.add(mountUrl);
         removeButton();
       }

--- a/src/youtube_summary.js
+++ b/src/youtube_summary.js
@@ -554,6 +554,26 @@ function getCaptionTracks(playerResponse) {
   return playerResponse?.captions?.playerCaptionsTracklistRenderer?.captionTracks ?? [];
 }
 
+/**
+ * 轮询等待 playerResponse 中的 captionTracks 数据，最多等待 TRANSCRIPT_DOM_WAIT_MS 毫秒。
+ * 返回 true 表示视频有可用字幕；返回 false 表示无字幕（直播/无字幕视频）。
+ */
+async function hasCaptionTracks() {
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < TRANSCRIPT_DOM_WAIT_MS) {
+    const playerResponse = getPlayerResponseFromPageScripts();
+    if (playerResponse) {
+      // playerResponse 已解析，直接判断 captionTracks
+      return getCaptionTracks(playerResponse).length > 0;
+    }
+    await new Promise((resolve) => { setTimeout(resolve, TRANSCRIPT_DOM_POLL_MS); });
+  }
+
+  // 超时仍未找到 playerResponse，保守地返回 true 避免误隐藏
+  return true;
+}
+
 function getActiveCaptionLanguageCode() {
   const subtitlesButton = document.querySelector('.ytp-subtitles-button');
   const isPressed = subtitlesButton?.getAttribute('aria-pressed') === 'true';
@@ -952,12 +972,22 @@ function mountButton() {
 
   const summaryButton = createButton();
   subtitlesButton.insertAdjacentElement('afterend', summaryButton);
-  
+
   const transcriptButton = createTranscriptButton();
   summaryButton.insertAdjacentElement('afterend', transcriptButton);
 
   const downloadButton = createDownloadButton();
   transcriptButton.insertAdjacentElement('afterend', downloadButton);
+
+  // 挂载后异步检测字幕可用性：若该视频无字幕轨道则移除按钮，避免误导用户
+  hasCaptionTracks().then((captionsAvailable) => {
+    if (!captionsAvailable) {
+      log('该视频没有可用的字幕轨道，移除已挂载的功能按钮。');
+      removeButton();
+    }
+  }).catch(() => {
+    // 检测失败时保守保留按钮，让用户自行尝试
+  });
 }
 
 function handleNavigation() {

--- a/src/youtube_summary.js
+++ b/src/youtube_summary.js
@@ -24,6 +24,8 @@ let mountTimer = null;
 let statusTimer = null;
 let observerTimer = null;
 let observerRetryTimer = null;
+let latestCaptionCheckId = 0;
+const noCaptionUrls = new Set();
 
 function log(...args) {
   if (DEBUG) {
@@ -947,6 +949,11 @@ function mountButton() {
     return;
   }
 
+  // 已知无字幕的视频，直接跳过挂载，防止 Observer 触发无限循环
+  if (noCaptionUrls.has(window.location.href)) {
+    return;
+  }
+
   if (
     document.getElementById(YOUTUBE_SUMMARY_BUTTON_ID) &&
     document.getElementById(YOUTUBE_TRANSCRIPT_BUTTON_ID) &&
@@ -980,14 +987,23 @@ function mountButton() {
   transcriptButton.insertAdjacentElement('afterend', downloadButton);
 
   // 挂载后异步检测字幕可用性：若该视频无字幕轨道则移除按钮，避免误导用户
-  hasCaptionTracks().then((captionsAvailable) => {
-    if (!captionsAvailable) {
-      log('该视频没有可用的字幕轨道，移除已挂载的功能按钮。');
-      removeButton();
+  const captionCheckId = ++latestCaptionCheckId;
+  const mountUrl = window.location.href;
+  (async () => {
+    try {
+      const captionsAvailable = await hasCaptionTracks();
+      // 竞态保护：若检测期间已切换视频或触发了新一轮挂载，则丢弃过期结果
+      if (captionCheckId !== latestCaptionCheckId) return;
+      if (mountUrl !== window.location.href) return;
+      if (!captionsAvailable) {
+        log('该视频没有可用的字幕轨道，移除已挂载的功能按钮。');
+        noCaptionUrls.add(mountUrl);
+        removeButton();
+      }
+    } catch {
+      // 检测失败时保守保留按钮，让用户自行尝试
     }
-  }).catch(() => {
-    // 检测失败时保守保留按钮，让用户自行尝试
-  });
+  })();
 }
 
 function handleNavigation() {
@@ -997,6 +1013,8 @@ function handleNavigation() {
   }
 
   lastUrl = window.location.href;
+  // 切换视频时递增 captionCheckId，使前一次异步检测自动失效
+  latestCaptionCheckId += 1;
   removeButton();
   mountButton();
   observePlayerControls();


### PR DESCRIPTION
### 描述
在无字幕的 YouTube 视频中，视频控制条上挂载的功能按钮会带来不必要的视觉负担，且用户点击后无法得出任何结果，造成挫败感。

本 PR 优化了按钮挂载流程：
1. **同步挂载**：初始时依旧同步挂载按钮，确保不破坏现有单元测试对 DOM 结构的同步依赖；
2. **异步检测与自动移除**：挂载后，异步获取视频并检测是否包含 captionTracks。若检测到无字幕轨道，则静默将已挂载的功能按钮移除。

### 验证
- 已通过全部 65 项单元测试。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The extension now checks whether caption tracks are available on YouTube watch pages before presenting summary, transcript, and download features, avoiding incorrect or unusable UI.
  * Added smart caching and navigation-safe validation so stale checks don’t affect results when you move between pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->