### PR TITLE
fix(workflow): explicitly specify release-please config files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          config-file: .release-please-config.json
+          manifest-file: release-please-manifest.json
 
       - name: Checkout code
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
Explicitly configure config-file and manifest-file for release-please-action. This fixes the 'Missing required manifest config' error that causes the release workflow to fail.