### PR TITLE
fix(youtube): harden transcript fallback chain for SPA navigation and json3 variants

### DIFF
--- a/src/youtube_summary.js
+++ b/src/youtube_summary.js
@@ -170,6 +170,18 @@ function getTranscriptParamsFromPageScripts() {
   return '';
 }
 
+// SPA 导航后 <script> 标签可能不包含当前视频数据，以下函数从 HTML 字符串中提取
+function getInnertubeValueFromHtml(html, name) {
+  const pattern = new RegExp(`"${name}"\\s*:\\s*"([^"]+)"`);
+  const match = html.match(pattern);
+  return match ? match[1] : '';
+}
+
+function getTranscriptParamsFromHtml(html) {
+  const match = html.match(/"getTranscriptEndpoint"\s*:\s*\{"params"\s*:\s*"([^"]+)"/);
+  return match ? match[1] : '';
+}
+
 function normalizeTimestamp(timestamp) {
   const parts = timestamp.trim().split(':');
   if (parts.length >= 2) {
@@ -323,8 +335,16 @@ function isTranscriptPanelButton(button) {
   }
 
   const panel = button.closest('ytd-engagement-panel-section-list-renderer');
-  if (panel && !isElementVisible(panel)) {
-    return true;
+  if (panel) {
+    const targetId = panel.getAttribute('target-id');
+    // 绝对不能误过滤普通结构化描述容器（其 target-id 为 engagement-panel-structured-description）中的“显示字幕”按钮
+    if (targetId === 'engagement-panel-structured-description') {
+      return false;
+    }
+
+    if (!isElementVisible(panel)) {
+      return true;
+    }
   }
 
   return panelHasTranscriptContent(panel);
@@ -365,7 +385,28 @@ function findTranscriptButton({ allowHidden = false } = {}) {
 function expandDescription() {
   const container = document.querySelector('ytd-watch-metadata') || document.querySelector('ytd-video-secondary-info-renderer');
   if (!container) {
-    return;
+    return false;
+  }
+
+  // 优先尝试点击新版 YouTube 中的描述展开组件以激活结构化内容
+  const inlineExpander = container.querySelector('ytd-text-inline-expander');
+  if (inlineExpander) {
+    const expandBtn = inlineExpander.querySelector('#expand');
+    // 如果存在 #expand 且它没有被 hidden（表示还未展开）
+    if (expandBtn && !expandBtn.hasAttribute('hidden') && expandBtn.getAttribute('aria-hidden') !== 'true') {
+      inlineExpander.click();
+      expandBtn.click();
+      return true;
+    }
+  }
+
+  const divDesc = container.querySelector('div#description');
+  if (divDesc) {
+    const expandPattern = /\.\.\.(?:more|更多)|show more|展开|展開|顯示更多|显示更多/i;
+    if (expandPattern.test(divDesc.textContent || '')) {
+      divDesc.click();
+      return true;
+    }
   }
 
   const expandPattern = /\.\.\.(?:more|更多)|show more|展开|展開|顯示更多|显示更多/i;
@@ -509,12 +550,27 @@ async function fetchCurrentPlayerResponse() {
 }
 
 async function fetchInnertubeTranscript() {
-  const key = getInnertubeValue('INNERTUBE_API_KEY');
-  const clientVersion = getInnertubeValue('INNERTUBE_CLIENT_VERSION');
-  const visitorData = getInnertubeValue('VISITOR_DATA');
-  const hl = getInnertubeValue('HL') || document.documentElement.lang || 'en';
-  const gl = getInnertubeValue('GL') || 'US';
-  const params = getTranscriptParamsFromPageScripts();
+  let key = getInnertubeValue('INNERTUBE_API_KEY');
+  let clientVersion = getInnertubeValue('INNERTUBE_CLIENT_VERSION');
+  let visitorData = getInnertubeValue('VISITOR_DATA');
+  let hl = getInnertubeValue('HL') || document.documentElement.lang || 'en';
+  let gl = getInnertubeValue('GL') || 'US';
+  let params = getTranscriptParamsFromPageScripts();
+
+  // SPA 导航后 <script> 标签可能不包含当前视频的 params，从重新拉取的 HTML 中提取
+  if (!key || !clientVersion || !params) {
+    const html = await fetch(window.location.href, { credentials: 'include' })
+      .then((r) => r.ok ? r.text() : '')
+      .catch(() => '');
+    if (html) {
+      key = key || getInnertubeValueFromHtml(html, 'INNERTUBE_API_KEY');
+      clientVersion = clientVersion || getInnertubeValueFromHtml(html, 'INNERTUBE_CLIENT_VERSION');
+      visitorData = visitorData || getInnertubeValueFromHtml(html, 'VISITOR_DATA');
+      hl = hl || getInnertubeValueFromHtml(html, 'HL') || 'en';
+      gl = gl || getInnertubeValueFromHtml(html, 'GL') || 'US';
+      params = params || getTranscriptParamsFromHtml(html);
+    }
+  }
 
   if (!key || !clientVersion || !params) {
     throw new Error('innertube_missing_config');

--- a/src/youtube_transcript.js
+++ b/src/youtube_transcript.js
@@ -101,21 +101,26 @@
       return '';
     }
 
-    if (!Array.isArray(data.events)) {
+    // YouTube json3 格式存在多种结构变体，按优先级依次尝试
+    const events = data.events ?? data.wireCues ?? data.wpCues ?? null;
+    if (!Array.isArray(events)) {
       return '';
     }
 
-    return data.events
+    return events
       .map((event) => {
-        const text = Array.isArray(event.segs)
-          ? event.segs.map((segment) => segment?.utf8 ?? '').join('').trim()
-          : '';
+        // 兼容多种字段名: segs / cues / wpSegs
+        const segments = event.segs ?? event.cues ?? event.wpSegs;
+        const text = Array.isArray(segments)
+          ? segments.map((segment) => segment?.utf8 ?? '').join('').trim()
+          : (event.utf8 ?? '').trim();
 
         if (!text) {
           return '';
         }
 
-        return `[${formatTimestamp((event.tStartMs ?? 0) / 1000)}] ${text}`;
+        const startMs = event.tStartMs ?? event.wpTStartMs ?? 0;
+        return `[${formatTimestamp(startMs / 1000)}] ${text}`;
       })
       .filter(Boolean)
       .join('\n');

--- a/tests/youtube_transcript.test.js
+++ b/tests/youtube_transcript.test.js
@@ -244,5 +244,45 @@ test('convertToTxt handles empty or invalid transcript gracefully', () => {
   assert.equal(convertToTxt(null), '');
 });
 
+test('parseTranscript handles wireCues json3 variant', () => {
+  const { parseTranscript } = loadHelpers();
+  const json = JSON.stringify({
+    wireCues: [
+      { tStartMs: 1000, cues: [{ utf8: 'Wire cue line' }] },
+      { tStartMs: 65000, cues: [{ utf8: 'Second ' }, { utf8: 'wire' }] },
+    ],
+  });
 
+  assert.equal(parseTranscript(json), '[00:01] Wire cue line\n[01:05] Second wire');
+});
+
+test('parseTranscript handles wpCues json3 variant', () => {
+  const { parseTranscript } = loadHelpers();
+  const json = JSON.stringify({
+    wpCues: [
+      { wpTStartMs: 2000, wpSegs: [{ utf8: 'WP cue line' }] },
+      { wpTStartMs: 130000, wpSegs: [{ utf8: 'Another' }] },
+    ],
+  });
+
+  assert.equal(parseTranscript(json), '[00:02] WP cue line\n[02:10] Another');
+});
+
+test('parseTranscript handles events with top-level utf8 field', () => {
+  const { parseTranscript } = loadHelpers();
+  const json = JSON.stringify({
+    events: [
+      { tStartMs: 500, utf8: 'Direct text' },
+      { tStartMs: 3000, utf8: 'More text' },
+    ],
+  });
+
+  assert.equal(parseTranscript(json), '[00:00] Direct text\n[00:03] More text');
+});
+
+test('parseTranscript returns empty for unknown json structure', () => {
+  const { parseTranscript } = loadHelpers();
+  const json = JSON.stringify({ unknownKey: [{ data: 'test' }] });
+  assert.equal(parseTranscript(json), '');
+});
 


### PR DESCRIPTION
## Problem

When downloading subtitles from a YouTube video in playlist mode (SPA navigation), all three fallback paths fail:

```
empty_transcript: timedtext_empty, innertube_missing_config, transcript_dom_empty
```

## Root Cause

### 1. `timedtext_empty` — `parseTranscriptJson` only handled `events` + `segs` structure

`buildCaptionUrl` forces `fmt=json3`, but `parseTranscriptJson` only handled the standard `{ events: [{ tStartMs, segs: [{ utf8 }] }] }` structure. YouTube's json3 format has multiple variants (`wireCues`, `wpCues`, top-level `utf8`), all of which returned empty.

### 2. `innertube_missing_config` — SPA navigation breaks `<script>` tag scanning

`getTranscriptParamsFromPageScripts()` scans `document.scripts` text content for `getTranscriptEndpoint` params. During YouTube SPA navigation (playlist autoplay), the `<script>` tags contain stale data from the initial page load — the current video's transcript params are missing.

## Fix

### Parser Enhancement (`youtube_transcript.js`)
- `parseTranscriptJson` now tries `data.events ?? data.wireCues ?? data.wpCues` for the events array
- Segment text is extracted from `event.segs ?? event.cues ?? event.wpSegs`, with a `event.utf8` fallback
- Start time reads `event.tStartMs ?? event.wpTStartMs`

### InnerTube Fallback (`youtube_summary.js`)
- When `<script>` tag scanning fails to find `key`, `clientVersion`, or `params`, the code now re-fetches the watch page HTML via `fetch(window.location.href)` and extracts the missing values from the fresh HTML
- New helper functions `getInnertubeValueFromHtml()` and `getTranscriptParamsFromHtml()` handle the HTML string extraction

### Tests
- 4 new test cases for `wireCues`, `wpCues`, top-level `utf8`, and unknown JSON structures

## Testing
- `npm test` — 69/69 pass
- `node --check` — syntax OK for all modified files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved transcript extraction to support more YouTube page and caption formats, including newer navigation and layout patterns.
  * Added broader handling for transcript caption data, so more videos can display timestamped transcript lines.

* **Bug Fixes**
  * Reduced false matches when detecting the transcript panel.
  * Improved description expansion so “show more” controls are found more reliably.
  * Better fallback behavior when required transcript data isn’t immediately available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->