### PR TITLE
fix: keep timestamps and line breaks in TXT subtitle downloads

### DIFF
--- a/src/youtube_summary.js
+++ b/src/youtube_summary.js
@@ -170,6 +170,18 @@ function getTranscriptParamsFromPageScripts() {
   return '';
 }
 
+// SPA 导航后 <script> 标签可能不包含当前视频数据，以下函数从 HTML 字符串中提取
+function getInnertubeValueFromHtml(html, name) {
+  const pattern = new RegExp(`"${name}"\\s*:\\s*"([^"]+)"`);
+  const match = html.match(pattern);
+  return match ? match[1] : '';
+}
+
+function getTranscriptParamsFromHtml(html) {
+  const match = html.match(/"getTranscriptEndpoint"\s*:\s*\{"params"\s*:\s*"([^"]+)"/);
+  return match ? match[1] : '';
+}
+
 function normalizeTimestamp(timestamp) {
   const parts = timestamp.trim().split(':');
   if (parts.length >= 2) {
@@ -323,8 +335,16 @@ function isTranscriptPanelButton(button) {
   }
 
   const panel = button.closest('ytd-engagement-panel-section-list-renderer');
-  if (panel && !isElementVisible(panel)) {
-    return true;
+  if (panel) {
+    const targetId = panel.getAttribute('target-id');
+    // 绝对不能误过滤普通结构化描述容器（其 target-id 为 engagement-panel-structured-description）中的“显示字幕”按钮
+    if (targetId === 'engagement-panel-structured-description') {
+      return false;
+    }
+
+    if (!isElementVisible(panel)) {
+      return true;
+    }
   }
 
   return panelHasTranscriptContent(panel);
@@ -365,7 +385,28 @@ function findTranscriptButton({ allowHidden = false } = {}) {
 function expandDescription() {
   const container = document.querySelector('ytd-watch-metadata') || document.querySelector('ytd-video-secondary-info-renderer');
   if (!container) {
-    return;
+    return false;
+  }
+
+  // 优先尝试点击新版 YouTube 中的描述展开组件以激活结构化内容
+  const inlineExpander = container.querySelector('ytd-text-inline-expander');
+  if (inlineExpander) {
+    const expandBtn = inlineExpander.querySelector('#expand');
+    // 如果存在 #expand 且它没有被 hidden（表示还未展开）
+    if (expandBtn && !expandBtn.hasAttribute('hidden') && expandBtn.getAttribute('aria-hidden') !== 'true') {
+      inlineExpander.click();
+      expandBtn.click();
+      return true;
+    }
+  }
+
+  const divDesc = container.querySelector('div#description');
+  if (divDesc) {
+    const expandPattern = /\.\.\.(?:more|更多)|show more|展开|展開|顯示更多|显示更多/i;
+    if (expandPattern.test(divDesc.textContent || '')) {
+      divDesc.click();
+      return true;
+    }
   }
 
   const expandPattern = /\.\.\.(?:more|更多)|show more|展开|展開|顯示更多|显示更多/i;
@@ -509,12 +550,27 @@ async function fetchCurrentPlayerResponse() {
 }
 
 async function fetchInnertubeTranscript() {
-  const key = getInnertubeValue('INNERTUBE_API_KEY');
-  const clientVersion = getInnertubeValue('INNERTUBE_CLIENT_VERSION');
-  const visitorData = getInnertubeValue('VISITOR_DATA');
-  const hl = getInnertubeValue('HL') || document.documentElement.lang || 'en';
-  const gl = getInnertubeValue('GL') || 'US';
-  const params = getTranscriptParamsFromPageScripts();
+  let key = getInnertubeValue('INNERTUBE_API_KEY');
+  let clientVersion = getInnertubeValue('INNERTUBE_CLIENT_VERSION');
+  let visitorData = getInnertubeValue('VISITOR_DATA');
+  let hl = getInnertubeValue('HL') || document.documentElement.lang || 'en';
+  let gl = getInnertubeValue('GL') || 'US';
+  let params = getTranscriptParamsFromPageScripts();
+
+  // SPA 导航后 <script> 标签可能不包含当前视频的 params，从重新拉取的 HTML 中提取
+  if (!key || !clientVersion || !params) {
+    const html = await fetch(window.location.href, { credentials: 'include' })
+      .then((r) => r.ok ? r.text() : '')
+      .catch(() => '');
+    if (html) {
+      key = key || getInnertubeValueFromHtml(html, 'INNERTUBE_API_KEY');
+      clientVersion = clientVersion || getInnertubeValueFromHtml(html, 'INNERTUBE_CLIENT_VERSION');
+      visitorData = visitorData || getInnertubeValueFromHtml(html, 'VISITOR_DATA');
+      hl = hl || getInnertubeValueFromHtml(html, 'HL') || 'en';
+      gl = gl || getInnertubeValueFromHtml(html, 'GL') || 'US';
+      params = params || getTranscriptParamsFromHtml(html);
+    }
+  }
 
   if (!key || !clientVersion || !params) {
     throw new Error('innertube_missing_config');

--- a/src/youtube_summary.js
+++ b/src/youtube_summary.js
@@ -388,13 +388,14 @@ function expandDescription() {
     return false;
   }
 
+  const expandPattern = /\.\.\.(?:more|更多)|show more|展开|展開|顯示更多|显示更多/i;
+
   // 优先尝试点击新版 YouTube 中的描述展开组件以激活结构化内容
   const inlineExpander = container.querySelector('ytd-text-inline-expander');
   if (inlineExpander) {
     const expandBtn = inlineExpander.querySelector('#expand');
-    // 如果存在 #expand 且它没有被 hidden（表示还未展开）
+    // 如果存在 #expand 且它没有被 hidden（表示还未展开），只点击 expandBtn 避免双击切换
     if (expandBtn && !expandBtn.hasAttribute('hidden') && expandBtn.getAttribute('aria-hidden') !== 'true') {
-      inlineExpander.click();
       expandBtn.click();
       return true;
     }
@@ -402,14 +403,12 @@ function expandDescription() {
 
   const divDesc = container.querySelector('div#description');
   if (divDesc) {
-    const expandPattern = /\.\.\.(?:more|更多)|show more|展开|展開|顯示更多|显示更多/i;
     if (expandPattern.test(divDesc.textContent || '')) {
       divDesc.click();
       return true;
     }
   }
 
-  const expandPattern = /\.\.\.(?:more|更多)|show more|展开|展開|顯示更多|显示更多/i;
   const expandElements = container.querySelectorAll('tp-yt-paper-button, button, [id="expand"], ytd-button-renderer, [role="button"]');
 
   for (const el of expandElements) {
@@ -559,15 +558,17 @@ async function fetchInnertubeTranscript() {
 
   // SPA 导航后 <script> 标签可能不包含当前视频的 params，从重新拉取的 HTML 中提取
   if (!key || !clientVersion || !params) {
-    const html = await fetch(window.location.href, { credentials: 'include' })
-      .then((r) => r.ok ? r.text() : '')
-      .catch(() => '');
+    let html = '';
+    try {
+      const r = await fetch(window.location.href, { credentials: 'include' });
+      html = r.ok ? await r.text() : '';
+    } catch {
+      html = '';
+    }
     if (html) {
       key = key || getInnertubeValueFromHtml(html, 'INNERTUBE_API_KEY');
       clientVersion = clientVersion || getInnertubeValueFromHtml(html, 'INNERTUBE_CLIENT_VERSION');
       visitorData = visitorData || getInnertubeValueFromHtml(html, 'VISITOR_DATA');
-      hl = hl || getInnertubeValueFromHtml(html, 'HL') || 'en';
-      gl = gl || getInnertubeValueFromHtml(html, 'GL') || 'US';
       params = params || getTranscriptParamsFromHtml(html);
     }
   }

--- a/src/youtube_transcript.js
+++ b/src/youtube_transcript.js
@@ -101,21 +101,26 @@
       return '';
     }
 
-    if (!Array.isArray(data.events)) {
+    // YouTube json3 格式存在多种结构变体，按优先级依次尝试
+    const events = data.events ?? data.wireCues ?? data.wpCues ?? null;
+    if (!Array.isArray(events)) {
       return '';
     }
 
-    return data.events
+    return events
       .map((event) => {
-        const text = Array.isArray(event.segs)
-          ? event.segs.map((segment) => segment?.utf8 ?? '').join('').trim()
-          : '';
+        // 兼容多种字段名: segs / cues / wpSegs
+        const segments = event.segs ?? event.cues ?? event.wpSegs;
+        const text = Array.isArray(segments)
+          ? segments.map((segment) => segment?.utf8 ?? '').join('').trim()
+          : (event.utf8 ?? '').trim();
 
         if (!text) {
           return '';
         }
 
-        return `[${formatTimestamp((event.tStartMs ?? 0) / 1000)}] ${text}`;
+        const startMs = event.tStartMs ?? event.wpTStartMs ?? 0;
+        return `[${formatTimestamp(startMs / 1000)}] ${text}`;
       })
       .filter(Boolean)
       .join('\n');

--- a/src/youtube_transcript.js
+++ b/src/youtube_transcript.js
@@ -110,16 +110,16 @@
     return events
       .map((event) => {
         // 兼容多种字段名: segs / cues / wpSegs
-        const segments = event.segs ?? event.cues ?? event.wpSegs;
+        const segments = event?.segs ?? event?.cues ?? event?.wpSegs;
         const text = Array.isArray(segments)
           ? segments.map((segment) => segment?.utf8 ?? '').join('').trim()
-          : (event.utf8 ?? '').trim();
+          : (event?.utf8 ?? '').trim();
 
         if (!text) {
           return '';
         }
 
-        const startMs = event.tStartMs ?? event.wpTStartMs ?? 0;
+        const startMs = event?.tStartMs ?? event?.wpTStartMs ?? 0;
         return `[${formatTimestamp(startMs / 1000)}] ${text}`;
       })
       .filter(Boolean)
@@ -319,17 +319,11 @@
       return '';
     }
 
-    const lines = transcriptText.split('\n').filter(Boolean);
-    const parsedLines = [];
-
-    for (const line of lines) {
-      const trimmed = line.trim();
-      if (trimmed) {
-        parsedLines.push(trimmed);
-      }
-    }
-
-    return parsedLines.join('\n');
+    return transcriptText
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .join('\n');
   }
 
   globalScope.ChatgptWebInjectorYoutubeTranscript = {

--- a/src/youtube_transcript.js
+++ b/src/youtube_transcript.js
@@ -320,17 +320,16 @@
     }
 
     const lines = transcriptText.split('\n').filter(Boolean);
-    const parsedTexts = [];
+    const parsedLines = [];
 
     for (const line of lines) {
-      const textStart = line.indexOf(']') + 1;
-      const text = textStart > 0 ? line.substring(textStart).trim() : line.trim();
-      if (text) {
-        parsedTexts.push(text);
+      const trimmed = line.trim();
+      if (trimmed) {
+        parsedLines.push(trimmed);
       }
     }
 
-    return parsedTexts.join(' ').replace(/\s+/g, ' ');
+    return parsedLines.join('\n');
   }
 
   globalScope.ChatgptWebInjectorYoutubeTranscript = {

--- a/tests/youtube_transcript.test.js
+++ b/tests/youtube_transcript.test.js
@@ -244,5 +244,45 @@ test('convertToTxt handles empty or invalid transcript gracefully', () => {
   assert.equal(convertToTxt(null), '');
 });
 
+test('parseTranscript handles wireCues json3 variant', () => {
+  const { parseTranscript } = loadHelpers();
+  const json = JSON.stringify({
+    wireCues: [
+      { tStartMs: 1000, cues: [{ utf8: 'Wire cue line' }] },
+      { tStartMs: 65000, cues: [{ utf8: 'Second ' }, { utf8: 'wire' }] },
+    ],
+  });
 
+  assert.equal(parseTranscript(json), '[00:01] Wire cue line\n[01:05] Second wire');
+});
+
+test('parseTranscript handles wpCues json3 variant', () => {
+  const { parseTranscript } = loadHelpers();
+  const json = JSON.stringify({
+    wpCues: [
+      { wpTStartMs: 2000, wpSegs: [{ utf8: 'WP cue line' }] },
+      { wpTStartMs: 130000, wpSegs: [{ utf8: 'Another' }] },
+    ],
+  });
+
+  assert.equal(parseTranscript(json), '[00:02] WP cue line\n[02:10] Another');
+});
+
+test('parseTranscript handles events with top-level utf8 field', () => {
+  const { parseTranscript } = loadHelpers();
+  const json = JSON.stringify({
+    events: [
+      { tStartMs: 500, utf8: 'Direct text' },
+      { tStartMs: 3000, utf8: 'More text' },
+    ],
+  });
+
+  assert.equal(parseTranscript(json), '[00:00] Direct text\n[00:03] More text');
+});
+
+test('parseTranscript returns empty for unknown json structure', () => {
+  const { parseTranscript } = loadHelpers();
+  const json = JSON.stringify({ unknownKey: [{ data: 'test' }] });
+  assert.equal(parseTranscript(json), '');
+});
 

--- a/tests/youtube_transcript.test.js
+++ b/tests/youtube_transcript.test.js
@@ -231,10 +231,10 @@ test('convertToSrt handles empty or invalid transcript gracefully', () => {
   assert.equal(convertToSrt('invalid text'), '');
 });
 
-test('convertToTxt converts transcript text by stripping timestamps and joining with spaces', () => {
+test('convertToTxt converts transcript text by keeping timestamps and splitting into lines', () => {
   const { convertToTxt } = loadHelpers();
   const transcript = '[00:12] Hello world\n[01:05] Next line\n[01:05:30] Third line';
-  const expected = 'Hello world Next line Third line';
+  const expected = '[00:12] Hello world\n[01:05] Next line\n[01:05:30] Third line';
   assert.equal(convertToTxt(transcript), expected);
 });
 


### PR DESCRIPTION
This PR fixes the issue where downloading subtitles in TXT format does not include timestamps.

### Proposed Changes
- Modified `convertToTxt` in `src/youtube_transcript.js` to keep timestamps (e.g., `[00:12] Hello world`) and preserve the line structure.
- Updated unit tests in `tests/youtube_transcript.test.js` to assert the correct output format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved transcript parsing to support additional YouTube JSON caption variants and more transcript text variants.
  * Added fallback behavior to re-extract missing transcript request parameters during YouTube SPA navigation.
* **Bug Fixes**
  * Reduced false matches for the transcript panel button inside structured description content.
  * Improved “expand description” interactions with inline expander preference and safer fallbacks.
  * Updated transcript text formatting to output timestamped segments as newline-separated rows.
* **Tests**
  * Expanded transcript parsing and formatting expectations for the new JSON variants and text output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->