### PR TITLE
docs: simplify README, highlight YouTube features as primary

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,108 +1,46 @@
 # ChatGPT Web Injector
 
+![Version](https://img.shields.io/badge/version-0.0.18-blue)
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
 ![Chrome Extension](https://img.shields.io/badge/Chrome-Extension-4285F4)
-![Status](https://img.shields.io/badge/status-v0.1--planning-blue)
 
-A local-first Chrome extension that sends selected webpage content into ChatGPT with reusable prompt templates.
-
-## Why this exists
-
-If you often do this loop:
-
-1. Select text on a webpage
-2. Copy
-3. Open ChatGPT
-4. Paste
-5. Add your analysis prompt manually
-
-...this extension removes most of that friction.
-
-## Core idea (v0.1)
-
-- Select text on any webpage
-- Right-click: **Send to ChatGPT**
-- Extension composes: `template + selection + page context`
-- Opens ChatGPT in a **new tab**
-- Attempts auto inject + auto send
-- If injection fails, shows a manual copy modal fallback
-
-No backend, no API key, no database.
+A Chrome extension that brings AI tooling directly into your browser — from YouTube video summaries to quick ChatGPT prompts.
 
 ---
 
-## Features (v0.1)
+## Features
 
-- Context menu trigger (`Send to ChatGPT`)
-- Local template system (editable in Options)
-- Template variables:
-  - `{{selection}}`
-  - `{{title}}`
-  - `{{url}}`
-- New-tab workflow
-- Auto-send default behavior
-- Manual copy fallback modal on injection failure
+### 🎬 YouTube AI Helper
 
----
+Injected controls appear next to the YouTube player's CC button — no extra clicks needed.
 
-## YouTube Helper & Subtitle Downloader (v0.0.18)
+- **AI Summary**: Opens a ChatGPT tab pre-loaded with the full video transcript, ready to summarize or ask questions.
+- **Transcript Panel**: Toggles the native YouTube transcript sidebar.
+- **Download Subtitles**: Choose your format from a popover:
+  - **SRT** — precise SubRip format with millisecond timestamps (`00:00:12,345`), sorted chronologically. Good for subtitle editors or archiving.
+  - **TXT** — timestamps stripped, clean plain text. Ideal for pasting directly into LLMs.
+- Buttons auto-hide when a video has no captions (live streams, uncaptioned uploads), so there's never UI clutter.
+- Handles YouTube's single-page navigation — no stale buttons or race conditions when switching between videos.
 
-A built-in suite that enables you to summarize YouTube videos, interact with transcript panels, and download subtitles directly from video player controls.
+### 📋 Prompt Templates
 
-- **Zero-intrusive Native Buttons**: Minimalist icons and controls (AI Summary, Transcript, Download Subtitles) are injected right next to the YouTube player's `CC` button, blending perfectly with native player aesthetics.
-- **Intelligent Button Visibility**: Automatically detects caption availability asynchronously upon video load. If a video does not have any captions (such as live streams or uploads without CC), all injected summary/download buttons are cleanly removed, preventing UI clutter and user frustration.
-- **Robust Single-Page-App (SPA) Navigation**: Utilizes request tracking (`latestCaptionCheckId`) and video ID checks to prevent stale UI states and race conditions when users navigate continuously between multiple videos without reloading the page.
-- **Dual Format Offline Download**: Clicking the download button displays a sleek popover menu providing two formats:
-  - **`SRT`**: High-precision SubRip format with accurate millisecond timestamps (`00:00:12,345`), sorted chronologically.
-  - **`TXT`**: Clean reader format with all timestamps and redundant linebreaks stripped, perfect for pasting directly into LLMs.
-- **100% Robust Fallback Chain & Expanders**: Heavy-duty extraction workflow powered by the timedtext API, InnerTube API, and direct DOM segment extraction. Includes compatibility layers that automatically expand modern YouTube description elements (`ytd-text-inline-expander`) and guard structured panels to locate native subtitle endpoints reliably.
-- **Memory Leak Protection**: Event listeners are carefully bound in the capture phase for reliability and automatically detached on menu closures, with FIFO limits applied to local states to keep long-running browser tabs lightweight.
+Edit your default prompt template from the extension's Options page.
 
----
+Available variables:
 
-## Product decisions (frozen)
-
-- Auto-send: **ON**
-- Variables: `selection + title + url`
-- Open behavior: **always new tab**
-- Multi-model: **reserved for future** (Gemini/Claude)
-- Default template language: **English**
-- Empty selection: **allowed**
-- Injection failure fallback: **manual copy modal**
-- Launch: **GitHub open-source first**
-
----
-
-## Installation (Developer mode)
-
-1. Clone this repository
-2. Open Chrome -> `chrome://extensions`
-3. Enable **Developer mode**
-4. Click **Load unpacked**
-5. Select this project folder
-
----
-
-## Usage
-
-1. Open any webpage
-2. Select any text (or none, if intentional)
-3. Right-click -> **Send to ChatGPT**
-4. Review/continue in ChatGPT
-
----
-
-## Options
-
-Open extension options to edit your default template.
+| Variable | Description |
+|---|---|
+| `{{selection}}` | The text you selected |
+| `{{title}}` | Page title |
+| `{{url}}` | Page URL |
 
 Example template:
 
-```text
+```
 You are a precise analysis assistant.
 
-Source title: {{title}}
-Source URL: {{url}}
+Source: {{title}}
+URL: {{url}}
 
 Selected content:
 {{selection}}
@@ -113,44 +51,32 @@ Please provide:
 3) Confidence level
 ```
 
+### 🖱️ Send Selection to ChatGPT
+
+Two ways to trigger:
+
+- **Right-click** any selected text → **Send to ChatGPT**
+- **Hover button** (BOT): appears near your cursor when you select text on any page
+
+Both open ChatGPT in a new tab, inject the composed prompt, and auto-send. If injection fails, a manual copy modal appears as a fallback.
+
+---
+
+## Installation
+
+1. Clone this repository
+2. Open Chrome → `chrome://extensions`
+3. Enable **Developer mode**
+4. Click **Load unpacked**
+5. Select this project folder
+
 ---
 
 ## Privacy
 
-- Local-first design
-- No custom server
-- No analytics in v0.1
-- Settings stored in `chrome.storage.sync`
-
----
-
-## Known limitations
-
-- ChatGPT DOM changes may break auto injection temporarily
-- Browser security/permission constraints may affect behavior on some pages
-- Auto-send reliability can vary with target UI changes
-
----
-
-## Roadmap
-
-### v0.2
-- Multiple templates
-- Optional keyboard shortcut
-- Optional “inject only” mode
-- Basic target switcher (ChatGPT / Gemini / Claude)
-
-### v0.3
-- Rich template variables
-- Better target adapters
-- Store-ready UX polishing
-
----
-
-## Project docs
-
-- Product requirements: `PRD.md`
-- Technical specification: `TECH_SPEC.md`
+- No backend, no API key, no analytics
+- Settings stored locally via `chrome.storage.sync`
+- Nothing leaves your browser except what you send to ChatGPT
 
 ---
 
@@ -158,14 +84,14 @@ Please provide:
 
 Issues and PRs are welcome.
 
-If you find a selector break due to UI updates, please open an issue with:
-- browser version
-- target page URL
-- screenshot (if possible)
-- expected vs actual behavior
+If a selector breaks due to a YouTube or ChatGPT UI update, please open an issue with:
+- Browser version
+- Page URL
+- Screenshot (if possible)
+- Expected vs actual behavior
 
 ---
 
 ## License
 
-TBD (MIT recommended)
+MIT


### PR DESCRIPTION
## Summary

Refactors the README to reflect the current state of the extension (v0.0.18) and removes outdated planning-phase content.

### Changes
- **Restructured feature order**: YouTube AI Helper is now the primary feature, followed by Prompt Templates, then Send Selection to ChatGPT
- **Removed**: `Why this exists`, `Core idea (v0.1)`, `Product decisions (frozen)`, `Roadmap`, `Project docs` links
- **Updated**: Version badge synced to `0.0.18`; License changed from `TBD` to `MIT`
- **YouTube section**: Rewritten from user perspective — removed internal implementation details, kept user-facing feature descriptions
- **Template section**: Added variable reference table for clarity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README with a new version badge and streamlined structure.
  * Refreshed feature descriptions for YouTube AI Helper, subtitle handling, and prompt templates.
  * Added clearer instructions for sending selected text to ChatGPT, including fallback behavior.
  * Simplified installation, privacy, contributing, and licensing information.
  * Removed outdated roadmap, limitations, and development details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->