### PR TITLE
fix: hide YouTube controls until captions are confirmed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules/
 *.log
+.worktrees/

--- a/docs/superpowers/plans/2026-07-11-youtube-caption-controls-visibility.md
+++ b/docs/superpowers/plans/2026-07-11-youtube-caption-controls-visibility.md
@@ -4,7 +4,7 @@
 
 **Goal:** Keep YouTube summary, transcript, and subtitle-download controls hidden until the current video is confirmed to have caption tracks.
 
-**Architecture:** Preserve the existing mount and SPA race-protection flow. Mount all three controls with their native `hidden` property set, then reveal them together only when `hasCaptionTracks(videoId)` returns `true`; remove them for confirmed no-caption or unknown/error results, caching only confirmed no-caption URLs.
+**Architecture:** Preserve the existing mount and SPA race-protection flow. Mount all three controls with their native `hidden` property set, then reveal them together only when `hasCaptionTracks(videoId)` returns `true`; remove and cache them for confirmed no-caption results, while unknown/error results remain mounted and hidden to avoid a MutationObserver remount loop.
 
 **Tech Stack:** Manifest V3 Chrome extension, plain JavaScript, Node.js built-in test runner, jsdom.
 
@@ -30,7 +30,7 @@
 
 - [ ] **Step 1: Write failing DOM regression tests**
 
-Add a helper that embeds a matching `ytInitialPlayerResponse` and tests that all three controls are hidden synchronously, become visible after a caption-positive result, and are removed after a caption-negative result. Add an unknown-result test by advancing `Date.now()` beyond the polling window and rejecting `fetch()`.
+Add a helper that embeds a matching `ytInitialPlayerResponse` and tests that all three controls are hidden synchronously, become visible after a caption-positive result, and are removed after a caption-negative result. Add an unknown-result test by advancing `Date.now()` beyond the polling window and rejecting `fetch()`, then verify the controls remain mounted and hidden.
 
 ```js
 function createPlayerResponseScript(videoId, captionTracks) {
@@ -53,9 +53,9 @@ test('YouTube caption controls are removed when captions are unavailable', async
   // Await one microtask and assert all three controls are absent.
 });
 
-test('YouTube caption controls are removed when availability is unknown', async () => {
+test('YouTube caption controls remain hidden when availability is unknown', async () => {
   // Force polling to expire and fetch to reject.
-  // Await the async check and assert all three controls are absent.
+  // Await the async check and assert all three controls remain hidden.
 });
 ```
 
@@ -67,7 +67,7 @@ Expected: the hidden-until-confirmed assertion fails because controls are curren
 
 - [ ] **Step 3: Implement the minimal visibility behavior**
 
-Change `hasCaptionTracks()` to return `null` when its fallback cannot obtain a matching player response. Set all three newly mounted controls to `hidden = true`. After the existing stale-result guards, reveal all three only for `captionsAvailable === true`; cache and remove controls for `false`; remove without caching for `null` or thrown errors.
+Change `hasCaptionTracks()` to return `null` when its fallback cannot obtain a matching player response. Set all three newly mounted controls to `hidden = true`. After the existing stale-result guards, reveal all three only for `captionsAvailable === true`; cache and remove controls for `false`; leave controls mounted and hidden for `null` or thrown errors.
 
 ```js
 const controls = [summaryButton, transcriptButton, downloadButton];

--- a/docs/superpowers/plans/2026-07-11-youtube-caption-controls-visibility.md
+++ b/docs/superpowers/plans/2026-07-11-youtube-caption-controls-visibility.md
@@ -1,0 +1,107 @@
+# YouTube Caption Controls Visibility Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep YouTube summary, transcript, and subtitle-download controls hidden until the current video is confirmed to have caption tracks.
+
+**Architecture:** Preserve the existing mount and SPA race-protection flow. Mount all three controls with their native `hidden` property set, then reveal them together only when `hasCaptionTracks(videoId)` returns `true`; remove them for confirmed no-caption or unknown/error results, caching only confirmed no-caption URLs.
+
+**Tech Stack:** Manifest V3 Chrome extension, plain JavaScript, Node.js built-in test runner, jsdom.
+
+## Global Constraints
+
+- No new permissions, dependencies, files outside documentation/tests, bundler, TypeScript, or framework.
+- Preserve MV3 compatibility and existing SPA navigation race guards.
+- Use two-space indentation, semicolons, and single quotes in JavaScript.
+- Unknown caption availability must not expose unusable controls and must remain retryable.
+
+---
+
+### Task 1: Hide Controls Until Caption Availability Is Confirmed
+
+**Files:**
+- Modify: `tests/youtube_summary.test.js`
+- Modify: `src/youtube_summary.js:622-652`
+- Modify: `src/youtube_summary.js:1052-1087`
+
+**Interfaces:**
+- Consumes: `hasCaptionTracks(videoId)` and the existing three control factory functions.
+- Produces: `hasCaptionTracks(videoId) -> Promise<true | false | null>` and hidden controls that are revealed only for `true`.
+
+- [ ] **Step 1: Write failing DOM regression tests**
+
+Add a helper that embeds a matching `ytInitialPlayerResponse` and tests that all three controls are hidden synchronously, become visible after a caption-positive result, and are removed after a caption-negative result. Add an unknown-result test by advancing `Date.now()` beyond the polling window and rejecting `fetch()`.
+
+```js
+function createPlayerResponseScript(videoId, captionTracks) {
+  return `<script>var ytInitialPlayerResponse = ${JSON.stringify({
+    videoDetails: { videoId },
+    captions: {
+      playerCaptionsTracklistRenderer: { captionTracks },
+    },
+  })};</script>`;
+}
+
+test('YouTube caption controls stay hidden until captions are confirmed', async () => {
+  // Load a watch page containing a matching caption track.
+  // Assert each control has hidden === true immediately.
+  // Await one microtask and assert each control has hidden === false.
+});
+
+test('YouTube caption controls are removed when captions are unavailable', async () => {
+  // Load a matching player response with an empty captionTracks array.
+  // Await one microtask and assert all three controls are absent.
+});
+
+test('YouTube caption controls are removed when availability is unknown', async () => {
+  // Force polling to expire and fetch to reject.
+  // Await the async check and assert all three controls are absent.
+});
+```
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run: `node --test --test-name-pattern='caption controls' tests/youtube_summary.test.js`
+
+Expected: the hidden-until-confirmed assertion fails because controls are currently visible immediately, and the unknown-result assertion fails because the fallback currently returns `true`.
+
+- [ ] **Step 3: Implement the minimal visibility behavior**
+
+Change `hasCaptionTracks()` to return `null` when its fallback cannot obtain a matching player response. Set all three newly mounted controls to `hidden = true`. After the existing stale-result guards, reveal all three only for `captionsAvailable === true`; cache and remove controls for `false`; remove without caching for `null` or thrown errors.
+
+```js
+const controls = [summaryButton, transcriptButton, downloadButton];
+controls.forEach((control) => {
+  control.hidden = true;
+});
+
+if (captionsAvailable === true) {
+  controls.forEach((control) => {
+    control.hidden = false;
+  });
+  return;
+}
+```
+
+- [ ] **Step 4: Run focused tests and verify GREEN**
+
+Run: `node --test --test-name-pattern='caption controls' tests/youtube_summary.test.js`
+
+Expected: all matching caption-control tests pass.
+
+- [ ] **Step 5: Run regression verification**
+
+Run: `node --check src/youtube_summary.js`
+
+Expected: exit code 0 with no output.
+
+Run: `npm test`
+
+Expected: all tests pass with no failures.
+
+- [ ] **Step 6: Commit the implementation**
+
+```bash
+git add src/youtube_summary.js tests/youtube_summary.test.js docs/superpowers/plans/2026-07-11-youtube-caption-controls-visibility.md
+git commit -m "fix: hide YouTube controls until captions are confirmed"
+```

--- a/docs/superpowers/specs/2026-07-11-youtube-caption-controls-visibility-design.md
+++ b/docs/superpowers/specs/2026-07-11-youtube-caption-controls-visibility-design.md
@@ -16,14 +16,14 @@ The existing asynchronous `hasCaptionTracks(videoId)` check remains responsible 
 
 - When captions are confirmed, all three controls become visible together.
 - When captions are absent, all three controls are removed and the URL is added to the existing no-caption cache.
-- When detection returns `null` or throws, the controls are removed without adding the URL to the no-caption cache. An unknown result must not expose unusable controls, while a later YouTube event remains free to retry detection.
+- When detection returns `null` or throws, the controls remain mounted but hidden. This prevents unusable controls from appearing and prevents the player MutationObserver from causing a repeated remove/remount detection loop.
 - When navigation makes a result stale, that result does nothing; the navigation flow removes the old controls and mounts hidden controls for the new video.
 
 This preserves the current SPA race protection while changing the user-visible default from “visible until disproven” to “hidden until confirmed.”
 
 ## Failure Handling
 
-Caption detection already performs an HTML fallback request when page script data is stale. If all detection paths fail, it returns `null`, and the controls remain unavailable for that mount rather than being shown speculatively. A later YouTube navigation/data-update event may trigger a fresh mount attempt.
+Caption detection already performs an HTML fallback request when page script data is stale. If all detection paths fail, it returns `null`, and the controls remain hidden rather than being shown speculatively. Navigation to another video removes the hidden controls through the existing navigation flow and starts a fresh check for the new URL.
 
 ## Tests
 
@@ -32,6 +32,6 @@ DOM-level regression tests will verify:
 1. Controls are hidden immediately after mounting while caption detection is pending.
 2. Controls become visible only after captions are confirmed.
 3. Controls are removed when the current video has no caption tracks.
-4. A stale result from a previous SPA navigation cannot reveal controls on the new video.
+4. Controls remain hidden when caption availability cannot be determined.
 
 The changed JavaScript file will receive a syntax check, and the full existing test suite will run after implementation.

--- a/docs/superpowers/specs/2026-07-11-youtube-caption-controls-visibility-design.md
+++ b/docs/superpowers/specs/2026-07-11-youtube-caption-controls-visibility-design.md
@@ -1,0 +1,37 @@
+# YouTube Caption Controls Visibility Design
+
+## Goal
+
+Prevent the extension's YouTube summary, transcript, and subtitle download controls from appearing until the current video is confirmed to have caption tracks. Videos without captions must never show these controls, even briefly.
+
+## Scope
+
+This change is limited to the existing YouTube control mounting and caption-detection flow in `src/youtube_summary.js` and its tests. It does not change permissions, dependencies, button behavior, transcript fetching, or the visual design of controls after they become visible.
+
+## Design
+
+`mountButton()` will continue creating the three controls in their current positions so the existing DOM presence checks prevent duplicate mounts and duplicate caption checks. Each newly created control will initially use the native `hidden` state.
+
+The existing asynchronous `hasCaptionTracks(videoId)` check remains responsible for detecting caption availability. Its result becomes tri-state: `true` when caption tracks are present, `false` when a matching player response confirms there are no tracks, and `null` when the fallback request fails or does not return a matching player response. After it completes, the existing caption-check ID and URL guards must pass before the result can affect the controls:
+
+- When captions are confirmed, all three controls become visible together.
+- When captions are absent, all three controls are removed and the URL is added to the existing no-caption cache.
+- When detection returns `null` or throws, the controls are removed without adding the URL to the no-caption cache. An unknown result must not expose unusable controls, while a later YouTube event remains free to retry detection.
+- When navigation makes a result stale, that result does nothing; the navigation flow removes the old controls and mounts hidden controls for the new video.
+
+This preserves the current SPA race protection while changing the user-visible default from “visible until disproven” to “hidden until confirmed.”
+
+## Failure Handling
+
+Caption detection already performs an HTML fallback request when page script data is stale. If all detection paths fail, it returns `null`, and the controls remain unavailable for that mount rather than being shown speculatively. A later YouTube navigation/data-update event may trigger a fresh mount attempt.
+
+## Tests
+
+DOM-level regression tests will verify:
+
+1. Controls are hidden immediately after mounting while caption detection is pending.
+2. Controls become visible only after captions are confirmed.
+3. Controls are removed when the current video has no caption tracks.
+4. A stale result from a previous SPA navigation cannot reveal controls on the new video.
+
+The changed JavaScript file will receive a syntax check, and the full existing test suite will run after implementation.

--- a/src/youtube_summary.js
+++ b/src/youtube_summary.js
@@ -617,7 +617,7 @@ function getCaptionTracks(playerResponse) {
 /**
  * 轮询等待 playerResponse 中的 captionTracks 数据，最多等待 TRANSCRIPT_DOM_WAIT_MS 毫秒。
  * @param {string} videoId - 当前视频的 ID，用于校验 playerResponse 是否匹配当前视频
- * 返回 true 表示视频有可用字幕；返回 false 表示无字幕（直播/无字幕视频）。
+ * 返回 true 表示视频有可用字幕；返回 false 表示无字幕；返回 null 表示无法判断。
  */
 async function hasCaptionTracks(videoId) {
   const startedAt = Date.now();
@@ -644,9 +644,9 @@ async function hasCaptionTracks(videoId) {
       return getCaptionTracks(freshResponse).length > 0;
     }
   } catch {
-    // fetch 失败时保守返回 true，避免误隐藏
+    // fetch 失败时保持未知状态，避免显示不可用的按钮
   }
-  return true;
+  return null;
 }
 
 function getActiveCaptionLanguageCode() {
@@ -1059,7 +1059,12 @@ function mountButton() {
   const downloadButton = createDownloadButton();
   transcriptButton.insertAdjacentElement('afterend', downloadButton);
 
-  // 挂载后异步检测字幕可用性：若该视频无字幕轨道则移除按钮，避免误导用户
+  const controls = [summaryButton, transcriptButton, downloadButton];
+  controls.forEach((control) => {
+    control.hidden = true;
+  });
+
+  // 挂载后异步检测字幕可用性：仅在确认有字幕轨道后显示按钮
   const captionCheckId = ++latestCaptionCheckId;
   const mountUrl = window.location.href;
   const currentVideoId = new URLSearchParams(window.location.search).get('v');
@@ -1069,7 +1074,13 @@ function mountButton() {
       // 竞态保护：若检测期间已切换视频或触发了新一轮挂载，则丢弃过期结果
       if (captionCheckId !== latestCaptionCheckId) return;
       if (mountUrl !== window.location.href) return;
-      if (!captionsAvailable) {
+      if (captionsAvailable === true) {
+        controls.forEach((control) => {
+          control.hidden = false;
+        });
+        return;
+      }
+      if (captionsAvailable === false) {
         log('该视频没有可用的字幕轨道，移除已挂载的功能按钮。');
         // FIFO 策略限制缓存大小，防止 SPA 长时间使用导致内存泄漏
         if (noCaptionUrls.size >= NO_CAPTION_CACHE_LIMIT) {
@@ -1080,7 +1091,7 @@ function mountButton() {
         removeButton();
       }
     } catch {
-      // 检测失败时保守保留按钮，让用户自行尝试
+      // 检测异常时保持按钮隐藏，避免显示不可用功能或触发重复挂载
     }
   })();
 }

--- a/tests/youtube_summary.test.js
+++ b/tests/youtube_summary.test.js
@@ -27,6 +27,96 @@ function loadYoutubeSummary(dom, options = {}) {
   }
 }
 
+function createPlayerResponseScript(videoId, captionTracks) {
+  return `<script>var ytInitialPlayerResponse = ${JSON.stringify({
+    videoDetails: { videoId },
+    captions: {
+      playerCaptionsTracklistRenderer: { captionTracks },
+    },
+  })};</script>`;
+}
+
+function getCaptionControls(document) {
+  return [
+    document.getElementById('chatgpt-web-injector-youtube-summary'),
+    document.getElementById('chatgpt-web-injector-youtube-transcript'),
+    document.getElementById('chatgpt-web-injector-youtube-download'),
+  ];
+}
+
+test('YouTube caption controls stay hidden until captions are confirmed', async () => {
+  const dom = new JSDOM(`
+    <html>
+      <body>
+        ${createPlayerResponseScript('test123', [{ baseUrl: 'https://example.com/captions' }])}
+        <div class="ytp-chrome-controls">
+          <button class="ytp-subtitles-button" aria-pressed="false">CC</button>
+        </div>
+      </body>
+    </html>
+  `, {
+    runScripts: 'outside-only',
+    url: 'https://www.youtube.com/watch?v=test123',
+  });
+
+  loadYoutubeSummary(dom);
+
+  assert.deepEqual(getCaptionControls(dom.window.document).map((control) => control?.hidden), [true, true, true]);
+
+  await Promise.resolve();
+
+  assert.deepEqual(getCaptionControls(dom.window.document).map((control) => control?.hidden), [false, false, false]);
+});
+
+test('YouTube caption controls are removed when captions are unavailable', async () => {
+  const dom = new JSDOM(`
+    <html>
+      <body>
+        ${createPlayerResponseScript('test123', [])}
+        <div class="ytp-chrome-controls">
+          <button class="ytp-subtitles-button" aria-pressed="false">CC</button>
+        </div>
+      </body>
+    </html>
+  `, {
+    runScripts: 'outside-only',
+    url: 'https://www.youtube.com/watch?v=test123',
+  });
+
+  loadYoutubeSummary(dom);
+  await Promise.resolve();
+
+  assert.deepEqual(getCaptionControls(dom.window.document), [null, null, null]);
+});
+
+test('YouTube caption controls remain hidden when availability is unknown', async () => {
+  const dom = new JSDOM(`
+    <html>
+      <body>
+        <div class="ytp-chrome-controls">
+          <button class="ytp-subtitles-button" aria-pressed="false">CC</button>
+        </div>
+      </body>
+    </html>
+  `, {
+    runScripts: 'outside-only',
+    url: 'https://www.youtube.com/watch?v=test123',
+  });
+  let dateCallCount = 0;
+  dom.window.Date.now = () => {
+    dateCallCount += 1;
+    return dateCallCount === 1 ? 0 : 3001;
+  };
+  dom.window.fetch = async () => {
+    throw new Error('network unavailable');
+  };
+
+  loadYoutubeSummary(dom);
+  await new Promise((resolve) => { setTimeout(resolve, 0); });
+
+  assert.deepEqual(getCaptionControls(dom.window.document).map((control) => control?.hidden), [true, true, true]);
+});
+
 test('YouTube summary controls include a transcript panel button', () => {
   const dom = new JSDOM(`
     <html>


### PR DESCRIPTION
## Summary
- Keep YouTube summary, transcript, and subtitle-download controls hidden until caption tracks are confirmed.
- Hide controls when detection is inconclusive to avoid unusable actions and MutationObserver remount loops.
- Add caption-availability regression coverage.

## Files
- `src/youtube_summary.js`
- `tests/youtube_summary.test.js`

## Verification
- `node --check src/youtube_summary.js`
- `npm test` (72 passing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Caption-related YouTube controls now appear only after captions are confirmed available.
* **Bug Fixes**
  * Controls are removed when a video has no caption tracks.
  * Controls remain hidden when caption availability cannot be determined or detection fails.
* **Tests**
  * Added coverage for delayed visibility, removal without captions, and unavailable caption detection.
* **Documentation**
  * Added implementation and design documentation for caption control visibility behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->