### PR TITLE
fix: show YouTube controls when captions are unknown

### DIFF
--- a/docs/superpowers/plans/2026-07-11-youtube-caption-controls-visibility.md
+++ b/docs/superpowers/plans/2026-07-11-youtube-caption-controls-visibility.md
@@ -4,7 +4,7 @@
 
 **Goal:** Keep YouTube summary, transcript, and subtitle-download controls hidden until the current video is confirmed to have caption tracks.
 
-**Architecture:** Preserve the existing mount and SPA race-protection flow. Mount all three controls with their native `hidden` property set, then reveal them together only when `hasCaptionTracks(videoId)` returns `true`; remove and cache them for confirmed no-caption results, while unknown/error results remain mounted and hidden to avoid a MutationObserver remount loop.
+**Architecture:** Preserve the existing mount and SPA race-protection flow. Mount all three controls with their native `hidden` property set, then reveal them together when `hasCaptionTracks(videoId)` returns `true` or `null`; remove and cache them only for confirmed no-caption results.
 
 **Tech Stack:** Manifest V3 Chrome extension, plain JavaScript, Node.js built-in test runner, jsdom.
 
@@ -30,7 +30,7 @@
 
 - [ ] **Step 1: Write failing DOM regression tests**
 
-Add a helper that embeds a matching `ytInitialPlayerResponse` and tests that all three controls are hidden synchronously, become visible after a caption-positive result, and are removed after a caption-negative result. Add an unknown-result test by advancing `Date.now()` beyond the polling window and rejecting `fetch()`, then verify the controls remain mounted and hidden.
+Add a helper that embeds a matching `ytInitialPlayerResponse` and tests that all three controls are hidden synchronously, become visible after a caption-positive result, and are removed after a caption-negative result. Add an unknown-result test by advancing `Date.now()` beyond the polling window and rejecting `fetch()`, then verify the controls become visible.
 
 ```js
 function createPlayerResponseScript(videoId, captionTracks) {
@@ -53,9 +53,9 @@ test('YouTube caption controls are removed when captions are unavailable', async
   // Await one microtask and assert all three controls are absent.
 });
 
-test('YouTube caption controls remain hidden when availability is unknown', async () => {
+test('YouTube caption controls are shown when availability is unknown', async () => {
   // Force polling to expire and fetch to reject.
-  // Await the async check and assert all three controls remain hidden.
+  // Await the async check and assert all three controls become visible.
 });
 ```
 
@@ -67,7 +67,7 @@ Expected: the hidden-until-confirmed assertion fails because controls are curren
 
 - [ ] **Step 3: Implement the minimal visibility behavior**
 
-Change `hasCaptionTracks()` to return `null` when its fallback cannot obtain a matching player response. Set all three newly mounted controls to `hidden = true`. After the existing stale-result guards, reveal all three only for `captionsAvailable === true`; cache and remove controls for `false`; leave controls mounted and hidden for `null` or thrown errors.
+Change `hasCaptionTracks()` to return `null` when its fallback cannot obtain a matching player response. Set all three newly mounted controls to `hidden = true`. After the existing stale-result guards, reveal all three for any result except `false`; cache and remove controls only for `false`; reveal controls for `null` or thrown errors.
 
 ```js
 const controls = [summaryButton, transcriptButton, downloadButton];

--- a/docs/superpowers/specs/2026-07-11-youtube-caption-controls-visibility-design.md
+++ b/docs/superpowers/specs/2026-07-11-youtube-caption-controls-visibility-design.md
@@ -16,14 +16,14 @@ The existing asynchronous `hasCaptionTracks(videoId)` check remains responsible 
 
 - When captions are confirmed, all three controls become visible together.
 - When captions are absent, all three controls are removed and the URL is added to the existing no-caption cache.
-- When detection returns `null` or throws, the controls remain mounted but hidden. This prevents unusable controls from appearing and prevents the player MutationObserver from causing a repeated remove/remount detection loop.
+- When detection returns `null` or throws, the controls become visible. This preserves the existing fallback for videos whose caption metadata is temporarily unavailable, while confirmed no-caption results remain hidden.
 - When navigation makes a result stale, that result does nothing; the navigation flow removes the old controls and mounts hidden controls for the new video.
 
 This preserves the current SPA race protection while changing the user-visible default from “visible until disproven” to “hidden until confirmed.”
 
 ## Failure Handling
 
-Caption detection already performs an HTML fallback request when page script data is stale. If all detection paths fail, it returns `null`, and the controls remain hidden rather than being shown speculatively. Navigation to another video removes the hidden controls through the existing navigation flow and starts a fresh check for the new URL.
+Caption detection already performs an HTML fallback request when page script data is stale. If all detection paths fail, it returns `null`, and the controls become visible as a fallback. Navigation to another video removes the old controls through the existing navigation flow and starts a fresh check for the new URL.
 
 ## Tests
 
@@ -32,6 +32,6 @@ DOM-level regression tests will verify:
 1. Controls are hidden immediately after mounting while caption detection is pending.
 2. Controls become visible only after captions are confirmed.
 3. Controls are removed when the current video has no caption tracks.
-4. Controls remain hidden when caption availability cannot be determined.
+4. Controls become visible when caption availability cannot be determined.
 
 The changed JavaScript file will receive a syntax check, and the full existing test suite will run after implementation.

--- a/src/youtube_summary.js
+++ b/src/youtube_summary.js
@@ -1063,6 +1063,11 @@ function mountButton() {
   controls.forEach((control) => {
     control.hidden = true;
   });
+  const revealControls = () => {
+    controls.forEach((control) => {
+      control.hidden = false;
+    });
+  };
 
   // 挂载后异步检测字幕可用性：仅在确认有字幕轨道后显示按钮
   const captionCheckId = ++latestCaptionCheckId;
@@ -1074,10 +1079,8 @@ function mountButton() {
       // 竞态保护：若检测期间已切换视频或触发了新一轮挂载，则丢弃过期结果
       if (captionCheckId !== latestCaptionCheckId) return;
       if (mountUrl !== window.location.href) return;
-      if (captionsAvailable === true) {
-        controls.forEach((control) => {
-          control.hidden = false;
-        });
+      if (captionsAvailable !== false) {
+        revealControls();
         return;
       }
       if (captionsAvailable === false) {
@@ -1091,7 +1094,9 @@ function mountButton() {
         removeButton();
       }
     } catch {
-      // 检测异常时保持按钮隐藏，避免显示不可用功能或触发重复挂载
+      if (captionCheckId !== latestCaptionCheckId) return;
+      if (mountUrl !== window.location.href) return;
+      revealControls();
     }
   })();
 }
@@ -1136,4 +1141,3 @@ function observePlayerControls() {
 observePlayerControls();
 handleNavigation();
 }());
-

--- a/tests/youtube_summary.test.js
+++ b/tests/youtube_summary.test.js
@@ -89,7 +89,7 @@ test('YouTube caption controls are removed when captions are unavailable', async
   assert.deepEqual(getCaptionControls(dom.window.document), [null, null, null]);
 });
 
-test('YouTube caption controls remain hidden when availability is unknown', async () => {
+test('YouTube caption controls are shown when availability is unknown', async () => {
   const dom = new JSDOM(`
     <html>
       <body>
@@ -114,7 +114,7 @@ test('YouTube caption controls remain hidden when availability is unknown', asyn
   loadYoutubeSummary(dom);
   await new Promise((resolve) => { setTimeout(resolve, 0); });
 
-  assert.deepEqual(getCaptionControls(dom.window.document).map((control) => control?.hidden), [true, true, true]);
+  assert.deepEqual(getCaptionControls(dom.window.document).map((control) => control?.hidden), [false, false, false]);
 });
 
 test('YouTube summary controls include a transcript panel button', () => {


### PR DESCRIPTION
## Summary
- Restore the existing fallback: show controls when caption metadata cannot be determined.
- Keep hiding controls only when the current video is confirmed to have no caption tracks.
- Add regression coverage for the unknown-metadata path.

## Verification
- `node --check src/youtube_summary.js`
- `npm test` (72 passing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Caption controls now appear when caption availability cannot be determined, including failed checks or unknown results.
  * Controls remain hidden only when captions are explicitly confirmed unavailable.
  * Improved handling of navigation-related caption checks to avoid applying stale results.

* **Tests**
  * Updated coverage to verify controls become visible when caption detection fails or expires.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->